### PR TITLE
create users and groups on Darwin when building

### DIFF
--- a/script/darwin-create-user
+++ b/script/darwin-create-user
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Create user on Darwin systems
+
+# take 3 arguments :    username
+#                       user id
+#                       group id
+
+USERNAME=$1
+USERID=$2
+GROUPID=$3
+
+sudo dscl . -create /Users/$USERNAME UniqueID $USERID
+sudo dscl . -create /Users/$USERNAME PrimaryGroupID $GROUPID

--- a/script/user-group
+++ b/script/user-group
@@ -30,12 +30,20 @@ INSTALLED=0
 
 if test `uname -s` = "FreeBSD"; then
   IS_FREEBSD=1
+  IS_DARWIN=0
+elif test `uname -s` = "Darwin"; then
+  IS_FREEBSD=0
+  IS_DARWIN=1
 else
   IS_FREEBSD=0
+  IS_DARWIN=0
 fi
 
 if test $IS_FREEBSD -eq 1; then
   CMD="pw groupadd $GROUPNAME"
+elif test $IS_DARWIN -eq 1; then
+  GROUPID=601
+  CMD="sudo dscl . -create /Groups/$GROUPNAME PrimaryGroupID $GROUPID"
 else
   CMD="groupadd $GROUPNAME"
 fi
@@ -94,6 +102,9 @@ else
   CMD=""
   if test "$IS_FREEBSD" -eq 1; then
     CMD="pw useradd $USERNAME -c $USERNAME"
+  elif test $IS_DARWIN -eq 1; then
+    USERID=601
+    CMD="sh $SRCDIR/script/darwin-create-user $USERNAME $USERID $GROUPID"
   elif useradd -D 2> /dev/null; then
     CMD="useradd -c '$USERNAME' -g $GROUPNAME $USERNAME"
   elif adduser -D 2> /dev/null; then


### PR DESCRIPTION
Was unable to create users and groups on macOS because "groupadd" and "useradd" only work on Linux. I've added a patch that detects if you're building on Darwin, and if you are, create the appropriate user and group using Darwin-specific commands. I set the user ID and the group ID both to 601. Feel free to change them, but be sure that no two users (or groups) will have the same ID by making it uncommon or adding some kind of script to detect unused IDs.