### PR TITLE
Feature/fix email From: w/ configurable "displayname"

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -4,99 +4,98 @@
 
 # @configure_input@
 
-
 # The following should not be edited manually (use configure options)
 # If you must do it, BEWARE : some of the following is also defined
 # in config.h, so you must modify config.h AND Makefile in order
 # to set the same values in the two files.
 
-FCRON_ALLOW	= fcron.allow
-FCRON_DENY	= fcron.deny
-FCRON_CONF	= fcron.conf
+# Please, keep assignments aligned with spaces.
+FCRON_ALLOW    = fcron.allow
+FCRON_DENY     = fcron.deny
+FCRON_CONF     = fcron.conf
 
-SRCDIR		:= @srcdir@
+SRCDIR        := @srcdir@
 # Useful to build packages
 # you may want to use this var with a : 'make DESTDIR=dir install'
-DESTDIR		:=
+DESTDIR       :=
 
 # Where should we install it ?
-prefix		= @prefix@
-exec_prefix	= @exec_prefix@
-DESTSBIN	= @sbindir@
-DESTBIN		= @bindir@
-ETC		= @sysconfdir@
-FCRONTABS	= @FCRONTABS@
-PIDDIR		= @PIDDIR@
-FIFODIR		= @FIFODIR@
-PIDFILE		= @PIDFILE@
-REBOOT_LOCK	= @REBOOT_LOCK@
-SUSPEND_FILE	= @SUSPEND_FILE@
-FIFOFILE	= @FIFOFILE@
-FCRON_SHELL	= @FCRON_SHELL@
-SENDMAIL	= @SENDMAIL@
-FCRON_EDITOR	= @FCRON_EDITOR@
-OPTIM		:= @CFLAGS@
-LDFLAGS		:= @LDFLAGS@
-CPPFLAGS	:= @CPPFLAGS@ -I. -I${SRCDIR}
-LIBS		:= @LIBS@
-LIBOBJS		:= @LIBOBJS@
-DEFS		:= @DEFS@
-CC		:= @CC@
-INSTALL		:= @INSTALL@
-STRIP		:= @STRIP@
-ROOTNAME	:= @ROOTNAME@
-ROOTGROUP	:= @ROOTGROUP@
-USERNAME 	:= @USERNAME@
-GROUPNAME	:= @GROUPNAME@
-SYSFCRONTAB	:= @SYSFCRONTAB@
-DEBUG		:= @DEBUG@
-BOOTINSTALL	:= @BOOTINSTALL@
-ANSWERALL	:= @ANSWERALL@
-USEPAM		:= @USEPAM@
-FCRONDYN	:= @FCRONDYN@
-SYSTEMD_DIR     := @SYSTEMD_DIR@
-DISPLAYNAME := @DISPLAYNAME@
+prefix         = @prefix@
+exec_prefix    = @exec_prefix@
+DESTSBIN       = @sbindir@
+DESTBIN        = @bindir@
+ETC            = @sysconfdir@
+FCRONTABS      = @FCRONTABS@
+PIDDIR         = @PIDDIR@
+FIFODIR        = @FIFODIR@
+PIDFILE        = @PIDFILE@
+REBOOT_LOCK    = @REBOOT_LOCK@
+SUSPEND_FILE   = @SUSPEND_FILE@
+FIFOFILE       = @FIFOFILE@
+FCRON_SHELL    = @FCRON_SHELL@
+SENDMAIL       = @SENDMAIL@
+FCRON_EDITOR   = @FCRON_EDITOR@
+OPTIM         := @CFLAGS@
+LDFLAGS       := @LDFLAGS@
+CPPFLAGS      := @CPPFLAGS@ -I. -I${SRCDIR}
+LIBS          := @LIBS@
+LIBOBJS       := @LIBOBJS@
+DEFS          := @DEFS@
+CC            := @CC@
+INSTALL       := @INSTALL@
+STRIP         := @STRIP@
+ROOTNAME      := @ROOTNAME@
+ROOTGROUP     := @ROOTGROUP@
+USERNAME      := @USERNAME@
+GROUPNAME     := @GROUPNAME@
+SYSFCRONTAB   := @SYSFCRONTAB@
+DEBUG         := @DEBUG@
+BOOTINSTALL   := @BOOTINSTALL@
+ANSWERALL     := @ANSWERALL@
+USEPAM        := @USEPAM@
+FCRONDYN      := @FCRONDYN@
+SYSTEMD_DIR   := @SYSTEMD_DIR@
+DISPLAYNAME   := @DISPLAYNAME@
 
 # Options
-#	-DDEBUG		even more verbose
-#	-DCHECKJOBS     send a mail containing the exact shell command
-#			for each execution of each job.
-#	-DFOREGROUND=[0|1]    default run in foreground ?
-#OPTION=	-DCHECKJOBS
-#OPTION=	-O3 -mcpu=i686
-OPTION :=
+#   -DDEBUG             even more verbose
+#   -DCHECKJOBS         send a mail containing the exact shell command
+#                       for each execution of each job.
+#   -DFOREGROUND=[0|1]  default run in foreground ?
+#OPTION        = -DCHECKJOBS
+#OPTION        = -O3 -mcpu=i686
+OPTION        :=
 
 
 ####################################
 # Should not be changed under this #
 ####################################
 
-VERSION := @VERSION@
-CFLAGS += $(OPTIM) $(OPTION) $(DEFS) $(CPPFLAGS) $(LDFLAGS)
+VERSION       := @VERSION@
+CFLAGS        += $(OPTIM) $(OPTION) $(DEFS) $(CPPFLAGS) $(LDFLAGS)
 ifeq ($(FCRONDYN), 1)
-LIBOBJS := $(LIBOBJS)
+	LIBOBJS   := $(LIBOBJS)
 endif
-OBJSD := fcron.o cl.o subs.o mem.o save.o temp_file.o log.o database.o job.o conf.o u_list.o exe_list.o lavg_list.o env_list.o fcronconf.o filesubs.o select.o fcrondyn_svr.o suspend.o $(LIBOBJS)
-OBJSTAB := fcrontab.o cl.o subs.o mem.o save.o temp_file.o  log.o fileconf.o allow.o read_string.o u_list.o env_list.o fcronconf.o filesubs.o
-OBJSDYN := fcrondyn.o subs.o mem.o log.o allow.o read_string.o fcronconf.o filesubs.o
-OBJCONV := convert-fcrontab.o cl.o subs.o mem.o save.o log.o u_list.o env_list.o fcronconf.o filesubs.o
-OBJSIG := fcronsighup.o subs.o mem.o log.o allow.o fcronconf.o filesubs.o
-HEADERSALL := config.h $(SRCDIR)/global.h $(SRCDIR)/cl.h $(SRCDIR)/log.h $(SRCDIR)/subs.h $(SRCDIR)/mem.h $(SRCDIR)/save.h $(SRCDIR)/option.h $(SRCDIR)/dyncom.h
+OBJSD         := fcron.o cl.o subs.o mem.o save.o temp_file.o log.o database.o job.o conf.o u_list.o exe_list.o lavg_list.o env_list.o fcronconf.o filesubs.o select.o fcrondyn_svr.o suspend.o $(LIBOBJS)
+OBJSTAB       := fcrontab.o cl.o subs.o mem.o save.o temp_file.o  log.o fileconf.o allow.o read_string.o u_list.o env_list.o fcronconf.o filesubs.o
+OBJSDYN       := fcrondyn.o subs.o mem.o log.o allow.o read_string.o fcronconf.o filesubs.o
+OBJCONV       := convert-fcrontab.o cl.o subs.o mem.o save.o log.o u_list.o env_list.o fcronconf.o filesubs.o
+OBJSIG        := fcronsighup.o subs.o mem.o log.o allow.o fcronconf.o filesubs.o
+HEADERSALL    := config.h $(SRCDIR)/global.h $(SRCDIR)/cl.h $(SRCDIR)/log.h $(SRCDIR)/subs.h $(SRCDIR)/mem.h $(SRCDIR)/save.h $(SRCDIR)/option.h $(SRCDIR)/dyncom.h
 
 # this is a regular expression :
 # do not ci automaticaly generated files and doc (done by doc's Makefile)
-RCSNOCI:=.*\(.html\|VERSION\|MANIFEST\|configure\|install.sh\|config.log\|config.status\|config.h\|config.cache\|Makefile\|doc.*\|CVS.*\|.git.*\)
+RCSNOCI       := .*\(.html\|VERSION\|MANIFEST\|configure\|install.sh\|config.log\|config.status\|config.h\|config.cache\|Makefile\|doc.*\|CVS.*\|.git.*\)
 
 RUN_NON_PRIVILEGED := @RUN_NON_PRIVILEGED@
 ifeq ($(RUN_NON_PRIVILEGED), 1)
-	BINMODE:=711
-	BINMODESIGHUP:=711
+	BINMODE        := 711
+	BINMODESIGHUP  := 711
 else
-	BINMODE:=6711
-	BINMODESIGHUP:=4710
+	BINMODE        := 6711
+	BINMODESIGHUP  := 4710
 endif
 
-export
 ifeq ($(FCRONDYN), 1)
 all: fcron fcrontab fcrondyn convert-fcrontab files/fcron.conf initscripts documentation
 else

--- a/Makefile.in
+++ b/Makefile.in
@@ -40,7 +40,7 @@ LDFLAGS		:= @LDFLAGS@
 CPPFLAGS	:= @CPPFLAGS@ -I. -I${SRCDIR}
 LIBS		:= @LIBS@
 LIBOBJS		:= @LIBOBJS@
-DEFS		:= @DEFS@ 
+DEFS		:= @DEFS@
 CC		:= @CC@
 INSTALL		:= @INSTALL@
 STRIP		:= @STRIP@
@@ -55,6 +55,7 @@ ANSWERALL	:= @ANSWERALL@
 USEPAM		:= @USEPAM@
 FCRONDYN	:= @FCRONDYN@
 SYSTEMD_DIR     := @SYSTEMD_DIR@
+DISPLAYNAME := @DISPLAYNAME@
 
 # Options
 #	-DDEBUG		even more verbose
@@ -63,7 +64,7 @@ SYSTEMD_DIR     := @SYSTEMD_DIR@
 #	-DFOREGROUND=[0|1]    default run in foreground ?
 #OPTION=	-DCHECKJOBS
 #OPTION=	-O3 -mcpu=i686
-OPTION := 
+OPTION :=
 
 
 ####################################
@@ -126,7 +127,7 @@ exe_list_test: exe_list.o u_list.o exe_list_test.o log.o subs.o
 	-DFCRONTABS="\"${FCRONTABS}\"" \
 	-DFCRON_ALLOW="\"${FCRON_ALLOW}\"" -DFCRON_DENY="\"${FCRON_DENY}\"" \
 	-DFCRON_SHELL="\"${FCRON_SHELL}\"" -DSENDMAIL="\"${SENDMAIL}\"" \
-	-DFCRON_EDITOR="\"${FCRON_EDITOR}\"" -DBINDIREX="\"${DESTBIN}\"" \
+	-DFCRON_EDITOR="\"${FCRON_EDITOR}\"" \-DDISPLAYNAME="\"${DISPLAYNAME}\"" -DBINDIREX="\"${DESTBIN}\"" \
 	-c $<
 
 initscripts:
@@ -138,7 +139,7 @@ initscripts:
 documentation:
 	$(MAKE) -C doc doc-if-none
 
-install: install-staged strip perms 
+install: install-staged strip perms
 ifeq ($(BOOTINSTALL), 1)
 	$(SRCDIR)/script/boot-install "$(INSTALL) -o $(ROOTNAME)" $(DESTSBIN) $(DEBUG) $(FCRONTABS) $(ANSWERALL) $(SRCDIR)
 endif
@@ -180,16 +181,16 @@ endif
 perms: install-staged strip
 # Note : we don't use "chown user:group file" because some systems use ":"
 #        and others "." as separator.
-	chown $(ROOTNAME) $(DESTDIR)$(DESTSBIN) 
-	chgrp $(ROOTGROUP) $(DESTDIR)$(DESTSBIN) 
-	chown $(ROOTNAME) $(DESTDIR)$(DESTBIN) 
-	chgrp $(ROOTGROUP) $(DESTDIR)$(DESTBIN) 
-	chown $(ROOTNAME) $(DESTDIR)$(ETC) 
-	chgrp $(ROOTGROUP) $(DESTDIR)$(ETC) 
-	chown $(ROOTNAME) $(DESTDIR)$(FIFODIR) 
-	chgrp $(ROOTGROUP) $(DESTDIR)$(FIFODIR) 
-	chown $(ROOTNAME) $(DESTDIR)$(PIDDIR) 
-	chgrp $(ROOTGROUP) $(DESTDIR)$(PIDDIR) 
+	chown $(ROOTNAME) $(DESTDIR)$(DESTSBIN)
+	chgrp $(ROOTGROUP) $(DESTDIR)$(DESTSBIN)
+	chown $(ROOTNAME) $(DESTDIR)$(DESTBIN)
+	chgrp $(ROOTGROUP) $(DESTDIR)$(DESTBIN)
+	chown $(ROOTNAME) $(DESTDIR)$(ETC)
+	chgrp $(ROOTGROUP) $(DESTDIR)$(ETC)
+	chown $(ROOTNAME) $(DESTDIR)$(FIFODIR)
+	chgrp $(ROOTGROUP) $(DESTDIR)$(FIFODIR)
+	chown $(ROOTNAME) $(DESTDIR)$(PIDDIR)
+	chgrp $(ROOTGROUP) $(DESTDIR)$(PIDDIR)
 
 # change spool dir mode
 	chown $(USERNAME) $(DESTDIR)$(FCRONTABS)
@@ -245,7 +246,7 @@ ifeq ($(FCRONDYN), 1)
 endif
 endif
 
-install-boot: install 
+install-boot: install
 	$(SRCDIR)/script/boot-install "$(INSTALL) -o $(ROOTNAME)" $(DESTSBIN) $(DEBUG) $(FCRONTABS)  $(ANSWERALL) $(SRCDIR)
 
 install-restart: install
@@ -291,7 +292,7 @@ indent:
             --dont-cuddle-else *.c *.h
 
 configure: configure.in
-# update configure script, then Makefile and config.h, and finally 
+# update configure script, then Makefile and config.h, and finally
 # run make tar using the new Makefile (needed because the version
 # is set in the configure.in file)
 	autoconf

--- a/Makefile.in
+++ b/Makefile.in
@@ -96,6 +96,7 @@ else
 	BINMODESIGHUP:=4710
 endif
 
+export
 ifeq ($(FCRONDYN), 1)
 all: fcron fcrontab fcrondyn convert-fcrontab files/fcron.conf initscripts documentation
 else
@@ -138,6 +139,11 @@ initscripts:
 
 documentation:
 	$(MAKE) -C doc doc-if-none
+
+.PHONY: test
+test:
+	$(MAKE) -C test tests
+
 
 install: install-staged strip perms
 ifeq ($(BOOTINSTALL), 1)
@@ -267,6 +273,7 @@ clean:
 	rm -f *.o core
 	rm -f fcron fcrontab fcrondyn fcronsighup convert-fcrontab files/fcron.conf
 	$(MAKE) -C doc clean
+	$(MAKE) -C test clean
 
 ciclean: clean
 	find ./ -name "*~" -exec rm -f {} \;
@@ -277,6 +284,7 @@ vclean: ciclean
             files/fcron.conf script/fcron.init.suse script/fcron.init.systemd script/fcron.init.systemd.reboot \
             script/fcron.sh script/sysVinit-launcher
 	$(MAKE) -C doc clean
+	$(MAKE) -C test clean
 
 
 files/fcron.conf: $(SRCDIR)/files/fcron.conf.in config.h

--- a/configure.in
+++ b/configure.in
@@ -128,10 +128,10 @@ AC_CHECK_LIB(kstat, kstat_open, [kstat=1], [kstat=0])
 if test $getloadavg -eq 1; then
 dnl Nothing to do ...
   AC_FUNC_GETLOADAVG
-  AC_MSG_CHECKING(function to use for lavg* options)  
+  AC_MSG_CHECKING(function to use for lavg* options)
   AC_MSG_RESULT(getloadavg())
 elif test $kstat -eq 1;  then
-  AC_MSG_CHECKING(function to use for lavg* options)  
+  AC_MSG_CHECKING(function to use for lavg* options)
   LIBS="$LIBS -lkstat"
   AC_LIBOBJ([getloadavg])
   AC_DEFINE_UNQUOTED(HAVE_KSTAT, 1)
@@ -139,7 +139,7 @@ elif test $kstat -eq 1;  then
 else
 dnl Try to use the /proc/loadavg file ...
   AC_FUNC_GETLOADAVG
-  AC_MSG_CHECKING(function to use for lavg* options)  
+  AC_MSG_CHECKING(function to use for lavg* options)
   AC_MSG_RESULT(/proc/loadavg)
 fi
 AC_CHECK_FUNCS(getcwd gettimeofday mktime putenv strerror setenv unsetenv gethostname)
@@ -200,7 +200,7 @@ dnl ---------------------------------------------------------------------
 fcron_enable_checks=yes
 AC_ARG_ENABLE(checks,
 [  --disable-checks   Don't verify that programs exist on the host ], dnl '
-[ case "$enableval" in 
+[ case "$enableval" in
    no)
      fcron_enable_checks=no
      ;;
@@ -212,7 +212,7 @@ AC_ARG_ENABLE(checks,
      ;;
   esac
 ])
-     
+
 
 dnl ---------------------------------------------------------------------
 dnl Programs ...
@@ -320,6 +320,11 @@ fi
 AC_MSG_RESULT([$FCRON_EDITOR])
 AC_SUBST([FCRON_EDITOR])
 
+DISPLAYNAME=
+AC_MSG_RESULT([$DISPLAYNAME])
+AC_SUBST([DISPLAYNAME])
+
+
 dnl ---------------------------------------------------------------------
 dnl Paths ...
 
@@ -397,7 +402,7 @@ AC_ARG_WITH(proc,
 [ case "$withval" in
   no)
     AC_MSG_WARN([
-Without proc, you won't be able to use the lavg* options 
+Without proc, you won't be able to use the lavg* options
 ])
     AC_DEFINE(NOLOADAVG)
     ;;
@@ -483,7 +488,7 @@ AC_ARG_WITH(run-non-privileged,
     AC_MSG_WARN([
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-WARNING : 
+WARNING :
 	This option allows a non privileged user to run fcron. When used,
 	fcron does not change its rights before running a job (i.e.,
 	if joe runs fcron, every job will run as joe).
@@ -591,7 +596,7 @@ AC_ARG_WITH(rootname,
   *)
 	rootname=$withval
     ;;
-  esac 
+  esac
 ])
 
 if test $fcron_enable_checks = 'yes'; then
@@ -924,13 +929,13 @@ AC_ARG_WITH(pam,
     AC_MSG_ERROR(Must be set to either "yes" or "no".)
     ;;
   esac ],
-  if test "$usepam" = "1"; then 
+  if test "$usepam" = "1"; then
     AC_MSG_RESULT(yes)
     AC_CHECK_LIB(pam, pam_acct_mgmt)
   else
     usepam=0
     AC_MSG_RESULT(no)
-  fi    
+  fi
 )
 if test "$usepam" != "0" && echo "$LIBS" | grep -- "-lpam" > /dev/null ; then
   usepam=1
@@ -959,7 +964,7 @@ AC_ARG_WITH(selinux,
     else
 	AC_MSG_RESULT(not available)
         AC_MSG_ERROR([
-  You requested the use of SELinux, but SELinux is considered 
+  You requested the use of SELinux, but SELinux is considered
   as not available by configure script.
 ])
     fi
@@ -999,7 +1004,7 @@ AC_MSG_CHECKING(Looking for docbook2man converter)
 AC_ARG_WITH(db2man,
 [ --with-db2man=PATH(or 'no')	set PATH to a docbook2man converter.],
 [ case "$withval" in
-  no) 
+  no)
     DB2MAN=""
     AC_MSG_RESULT(none)
     ;;
@@ -1028,7 +1033,7 @@ AC_ARG_WITH(db2man-spec,
 [ --with-db2man-spec=PATH	set the PATH to docbook2man-spec file
 				(needed if no db2man converter is set).],
 [ case "$withval" in
-  no) 
+  no)
     DB2MAN_SPEC=""
     AC_MSG_RESULT(none)
     ;;
@@ -1070,7 +1075,7 @@ AC_MSG_CHECKING(Looking for dsssl stylsheets)
 AC_ARG_WITH(dsssl-dir,
 [ --with-dsssl-dir=DIR	change the default location of DSSSL stylesheets.],
 [ case "$withval" in
-  no) 
+  no)
     DSSSL_DIR=""
     AC_MSG_RESULT(none)
     ;;

--- a/configure.in
+++ b/configure.in
@@ -5,9 +5,10 @@ dnl ---------------------------------------------------------------------
 dnl Initial settings
 dnl ---------------------------------------------------------------------
 
-AC_INIT(allow.c)
-AC_CONFIG_HEADER(config.h)
-AC_PREREQ(2.57)
+AC_INIT
+AC_CONFIG_SRCDIR([allow.c])
+AC_CONFIG_HEADERS([config.h])
+AC_PREREQ([2.71])
 m4_include([m4/ax_lib_readline.m4])
 
 vers="3.3.2"
@@ -47,7 +48,15 @@ dnl Checks for libraries.
 
 dnl Checks for header files.
 AC_HEADER_DIRENT
-AC_HEADER_STDC
+m4_warn([obsolete],
+[The preprocessor macro `STDC_HEADERS' is obsolete.
+  Except in unusual embedded environments, you can safely include all
+  ISO C90 headers unconditionally.])dnl
+# Autoupdate added the next two lines to ensure that your configure
+# script's behavior did not change.  They are probably safe to remove.
+AC_CHECK_INCLUDES_DEFAULT
+AC_PROG_EGREP
+
 AC_HEADER_SYS_WAIT
 AC_CHECK_HEADERS(fcntl.h sys/file.h sys/ioctl.h sys/time.h syslog.h unistd.h)
 AC_CHECK_HEADERS(errno.h sys/fcntl.h getopt.h limits.h)
@@ -63,7 +72,20 @@ dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
 AC_TYPE_PID_T
 AC_TYPE_SIZE_T
-AC_HEADER_TIME
+m4_warn([obsolete],
+[Update your code to rely only on HAVE_SYS_TIME_H,
+then remove this warning and the obsolete code below it.
+All current systems provide time.h; it need not be checked for.
+Not all systems provide sys/time.h, but those that do, all allow
+you to include it and time.h simultaneously.])dnl
+AC_CHECK_HEADERS_ONCE([sys/time.h])
+# Obsolete code to be removed.
+if test $ac_cv_header_sys_time_h = yes; then
+  AC_DEFINE([TIME_WITH_SYS_TIME],[1],[Define to 1 if you can safely include both <sys/time.h>
+	     and <time.h>.  This macro is obsolete.])
+fi
+# End of obsolete code.
+
 AC_STRUCT_TM
 AC_TYPE_UID_T
 
@@ -82,7 +104,19 @@ AC_CHECK_SIZEOF(long long int)
 dnl Checks for library functions.
 AC_PROG_GCC_TRADITIONAL
 AC_FUNC_MEMCMP
-AC_TYPE_SIGNAL
+m4_warn([obsolete],
+[your code may safely assume C89 semantics that RETSIGTYPE is void.
+Remove this warning and the `AC_CACHE_CHECK' when you adjust the code.])dnl
+AC_CACHE_CHECK([return type of signal handlers],[ac_cv_type_signal],[AC_COMPILE_IFELSE(
+[AC_LANG_PROGRAM([#include <sys/types.h>
+#include <signal.h>
+],
+		 [return *(signal (0, 0)) (0) == 1;])],
+		   [ac_cv_type_signal=int],
+		   [ac_cv_type_signal=void])])
+AC_DEFINE_UNQUOTED([RETSIGTYPE],[$ac_cv_type_signal],[Define as the return type of signal handlers
+		    (`int' or `void').])
+
 AC_FUNC_STRFTIME
 AC_FUNC_WAIT3
 AC_CHECK_LIB(xnet, shutdown)
@@ -147,10 +181,9 @@ dnl --- sockets
 dnl Check for post-Reno style struct sockaddr
 AC_CACHE_CHECK([for sa_len],
   ac_cv_sa_len,
-[AC_TRY_COMPILE([#include <sys/types.h>
-#include <sys/socket.h>], [int main(void) {
- struct sockaddr t;t.sa_len = 0;}],
-  ac_cv_sa_len=yes,ac_cv_sa_len=no)])
+[AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
+#include <sys/socket.h>]], [[int main(void) {
+ struct sockaddr t;t.sa_len = 0;}]])],[ac_cv_sa_len=yes],[ac_cv_sa_len=no])])
 if test $ac_cv_sa_len = yes; then
   AC_DEFINE(HAVE_SA_LEN)
 fi
@@ -1069,7 +1102,8 @@ dnl Final settings
 dnl ---------------------------------------------------------------------
 
 
-AC_OUTPUT(Makefile doc/Makefile doc/stylesheets/fcron-doc.dsl)
+AC_CONFIG_FILES([Makefile doc/Makefile doc/stylesheets/fcron-doc.dsl])
+AC_OUTPUT
 
 
 dnl ---------------------------------------------------------------------

--- a/configure.in
+++ b/configure.in
@@ -5,10 +5,9 @@ dnl ---------------------------------------------------------------------
 dnl Initial settings
 dnl ---------------------------------------------------------------------
 
-AC_INIT
-AC_CONFIG_SRCDIR([allow.c])
-AC_CONFIG_HEADERS([config.h])
-AC_PREREQ([2.71])
+AC_INIT(allow.c)
+AC_CONFIG_HEADER(config.h)
+AC_PREREQ(2.57)
 m4_include([m4/ax_lib_readline.m4])
 
 vers="3.3.2"
@@ -48,15 +47,7 @@ dnl Checks for libraries.
 
 dnl Checks for header files.
 AC_HEADER_DIRENT
-m4_warn([obsolete],
-[The preprocessor macro `STDC_HEADERS' is obsolete.
-  Except in unusual embedded environments, you can safely include all
-  ISO C90 headers unconditionally.])dnl
-# Autoupdate added the next two lines to ensure that your configure
-# script's behavior did not change.  They are probably safe to remove.
-AC_CHECK_INCLUDES_DEFAULT
-AC_PROG_EGREP
-
+AC_HEADER_STDC
 AC_HEADER_SYS_WAIT
 AC_CHECK_HEADERS(fcntl.h sys/file.h sys/ioctl.h sys/time.h syslog.h unistd.h)
 AC_CHECK_HEADERS(errno.h sys/fcntl.h getopt.h limits.h)
@@ -72,20 +63,7 @@ dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
 AC_TYPE_PID_T
 AC_TYPE_SIZE_T
-m4_warn([obsolete],
-[Update your code to rely only on HAVE_SYS_TIME_H,
-then remove this warning and the obsolete code below it.
-All current systems provide time.h; it need not be checked for.
-Not all systems provide sys/time.h, but those that do, all allow
-you to include it and time.h simultaneously.])dnl
-AC_CHECK_HEADERS_ONCE([sys/time.h])
-# Obsolete code to be removed.
-if test $ac_cv_header_sys_time_h = yes; then
-  AC_DEFINE([TIME_WITH_SYS_TIME],[1],[Define to 1 if you can safely include both <sys/time.h>
-	     and <time.h>.  This macro is obsolete.])
-fi
-# End of obsolete code.
-
+AC_HEADER_TIME
 AC_STRUCT_TM
 AC_TYPE_UID_T
 
@@ -104,19 +82,7 @@ AC_CHECK_SIZEOF(long long int)
 dnl Checks for library functions.
 AC_PROG_GCC_TRADITIONAL
 AC_FUNC_MEMCMP
-m4_warn([obsolete],
-[your code may safely assume C89 semantics that RETSIGTYPE is void.
-Remove this warning and the `AC_CACHE_CHECK' when you adjust the code.])dnl
-AC_CACHE_CHECK([return type of signal handlers],[ac_cv_type_signal],[AC_COMPILE_IFELSE(
-[AC_LANG_PROGRAM([#include <sys/types.h>
-#include <signal.h>
-],
-		 [return *(signal (0, 0)) (0) == 1;])],
-		   [ac_cv_type_signal=int],
-		   [ac_cv_type_signal=void])])
-AC_DEFINE_UNQUOTED([RETSIGTYPE],[$ac_cv_type_signal],[Define as the return type of signal handlers
-		    (`int' or `void').])
-
+AC_TYPE_SIGNAL
 AC_FUNC_STRFTIME
 AC_FUNC_WAIT3
 AC_CHECK_LIB(xnet, shutdown)
@@ -181,9 +147,10 @@ dnl --- sockets
 dnl Check for post-Reno style struct sockaddr
 AC_CACHE_CHECK([for sa_len],
   ac_cv_sa_len,
-[AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
-#include <sys/socket.h>]], [[int main(void) {
- struct sockaddr t;t.sa_len = 0;}]])],[ac_cv_sa_len=yes],[ac_cv_sa_len=no])])
+[AC_TRY_COMPILE([#include <sys/types.h>
+#include <sys/socket.h>], [int main(void) {
+ struct sockaddr t;t.sa_len = 0;}],
+  ac_cv_sa_len=yes,ac_cv_sa_len=no)])
 if test $ac_cv_sa_len = yes; then
   AC_DEFINE(HAVE_SA_LEN)
 fi
@@ -1107,8 +1074,7 @@ dnl Final settings
 dnl ---------------------------------------------------------------------
 
 
-AC_CONFIG_FILES([Makefile doc/Makefile doc/stylesheets/fcron-doc.dsl])
-AC_OUTPUT
+AC_OUTPUT(Makefile doc/Makefile doc/stylesheets/fcron-doc.dsl)
 
 
 dnl ---------------------------------------------------------------------

--- a/configure.in
+++ b/configure.in
@@ -414,6 +414,24 @@ AC_MSG_RESULT($docdir)
 DOCDIR="$docdir"
 AC_SUBST(DOCDIR)
 
+testdir="${datadir}/test"
+AC_MSG_CHECKING(location of test directory)
+AC_ARG_WITH(testdir,
+[  --with-testdir=PATH	Directory containing test executables.],
+[ case "$withval" in
+  no)
+    AC_MSG_ERROR(Need TESTDIR.)
+    ;;
+  yes)
+    ;;
+  *)
+    testdir="$withval"
+    ;;
+  esac ])
+
+AC_MSG_RESULT($testdir)
+TESTDIR="$testdir"
+AC_SUBST(TESTDIR)
 
 dnl systemd init system
 SYSTEMD_DIR="no"
@@ -1074,7 +1092,7 @@ dnl Final settings
 dnl ---------------------------------------------------------------------
 
 
-AC_OUTPUT(Makefile doc/Makefile doc/stylesheets/fcron-doc.dsl)
+AC_OUTPUT(Makefile doc/Makefile doc/stylesheets/fcron-doc.dsl test/Makefile)
 
 
 dnl ---------------------------------------------------------------------
@@ -1175,6 +1193,7 @@ echo "spool dir:                          $sp"
 echo "etc dir:                            $sysconfdir"
 echo "doc dir:                            $docdir"
 echo "man dir:                            $mandir "
+echo "test dir:                           $testdir "
 
 
 echo

--- a/configure.in
+++ b/configure.in
@@ -180,6 +180,10 @@ AC_ARG_ENABLE(checks,
   esac
 ])
 
+DISPLAYNAME=
+AC_MSG_RESULT([$DISPLAYNAME])
+AC_SUBST([DISPLAYNAME])
+
 
 dnl ---------------------------------------------------------------------
 dnl Programs ...
@@ -286,10 +290,6 @@ fi
 
 AC_MSG_RESULT([$FCRON_EDITOR])
 AC_SUBST([FCRON_EDITOR])
-
-DISPLAYNAME=
-AC_MSG_RESULT([$DISPLAYNAME])
-AC_SUBST([DISPLAYNAME])
 
 
 dnl ---------------------------------------------------------------------
@@ -414,24 +414,6 @@ AC_MSG_RESULT($docdir)
 DOCDIR="$docdir"
 AC_SUBST(DOCDIR)
 
-testdir="${datadir}/test"
-AC_MSG_CHECKING(location of test directory)
-AC_ARG_WITH(testdir,
-[  --with-testdir=PATH	Directory containing test executables.],
-[ case "$withval" in
-  no)
-    AC_MSG_ERROR(Need TESTDIR.)
-    ;;
-  yes)
-    ;;
-  *)
-    testdir="$withval"
-    ;;
-  esac ])
-
-AC_MSG_RESULT($testdir)
-TESTDIR="$testdir"
-AC_SUBST(TESTDIR)
 
 dnl systemd init system
 SYSTEMD_DIR="no"
@@ -1092,7 +1074,7 @@ dnl Final settings
 dnl ---------------------------------------------------------------------
 
 
-AC_OUTPUT(Makefile doc/Makefile doc/stylesheets/fcron-doc.dsl test/Makefile)
+AC_OUTPUT(Makefile doc/Makefile test/Makefile doc/stylesheets/fcron-doc.dsl)
 
 
 dnl ---------------------------------------------------------------------
@@ -1192,9 +1174,7 @@ echo "sbin dir:                           $sbindir"
 echo "spool dir:                          $sp"
 echo "etc dir:                            $sysconfdir"
 echo "doc dir:                            $docdir"
-echo "man dir:                            $mandir "
-echo "test dir:                           $testdir "
-
+echo "man dir:                            $mandir"
 
 echo
 echo "You can now run '$MAKE' to compile"

--- a/doc/en/fcron.conf.5.sgml
+++ b/doc/en/fcron.conf.5.sgml
@@ -1,4 +1,4 @@
-<!-- 
+<!--
 Fcron documentation
 Copyright 2000-2021 Thibault Godouet <fcron@free.fr>
 Permission is granted to copy, distribute and/or modify this
@@ -10,154 +10,228 @@ A copy of the license is included in gfdl.sgml.
 
 
 <refentry id="fcron.conf.5">
-    <refmeta>
-	<refentrytitle>fcron.conf</refentrytitle>
-	<manvolnum>5</manvolnum>
-	<refmiscinfo>Fcron &version; <![%devrelease; [
-(<emphasis>development</emphasis> release)]]></refmiscinfo>
-	<refmiscinfo>&date;</refmiscinfo>
-    </refmeta>
-    <refnamediv>
-	<refname>fcron.conf</refname>
-	<refpurpose>configuration file for fcron and fcrontab</refpurpose>
-    </refnamediv>
+	<refmeta>
+		<refentrytitle>fcron.conf</refentrytitle>
+		<manvolnum>5</manvolnum>
+		<refmiscinfo>Fcron &version;
+			<![%devrelease; [(<emphasis>development</emphasis> release)]]>
+		</refmiscinfo>
+		<refmiscinfo>&date;</refmiscinfo>
+	</refmeta>
+	<refnamediv>
+		<refname>fcron.conf</refname>
+		<refpurpose>configuration file for fcron and fcrontab</refpurpose>
+	</refnamediv>
 
-    <refsect1>
-	<title>Description</title>
-	<abstract>
-	    <para>This page describes the syntax used for the configuration file
-of <link linkend="fcrontab.1">&fcrontab;</link>(1), <link
-linkend="fcrondyn.1">&fcrondyn;</link>(1) and <link
-linkend="fcron.8">&fcron;</link>(8).</para>
-	</abstract>
-	<para>Blank lines, line beginning by a hash sign (#) (which are
-considered comments), leading blanks and tabs are ignored. Each line in a
-&fcron.conf; file is of the form
- <blockquote>
-		<para>name = value</para>
-	    </blockquote> where the blanks around equal-sign (=) are ignored and
-optional. Trailing blanks are also ignored.
-</para>
-	<para>The following names are recognized (default value in parentheses):
-<variablelist>
-		<title>Valid variables in a fcron.conf file</title>
-		<varlistentry>
-		    <term><varname>fcrontabs</varname>=<replaceable>directory</replaceable>
-(<filename>&fcrontabsdir;</filename>)</term>
-		    <listitem>
-			<para>&Fcron; spool directory.</para>
-		    </listitem>
-		</varlistentry>
-		<varlistentry>
-		    <term><varname>pidfile</varname>=<replaceable>file-path</replaceable>
-(<filename>&fcron.pid;</filename>)</term>
-		    <listitem>
-			<para>Location of &fcron; pid file (needed by &fcrontab;
-to work properly).</para>
-		    </listitem>
-		</varlistentry>
-		<varlistentry>
-		    <term><varname>suspendfile</varname>=<replaceable>file-path</replaceable>
-(<filename>&suspendfile;</filename>)</term>
-		    <listitem>
-			<para>Location of &fcron; suspend file. On non-Linux systems, this should be used to let fcron know how long the system was suspended (to memory or disk), so as task schedules can be updated accordingly.</para>
-		    </listitem>
-		</varlistentry>
-		<varlistentry>
-		    <term><varname>fifofile</varname>=<replaceable>file-path</replaceable> 
-(<filename>&fcron.fifo;</filename>)</term>
-		    <listitem>
-			<para>Location of &fcron; fifo file (needed by
-&fcrondyn; to communicate with &fcron;).</para>
-		    </listitem>
-		</varlistentry>
-		<varlistentry>
-		    <term><varname>fcronallow</varname>=<replaceable>file-path</replaceable> 
-(<filename>&etc;/&fcron.allow;</filename>)</term>
-		    <listitem>
-			<para>Location of fcron.allow file.</para>
-		    </listitem>
-		</varlistentry>
-		<varlistentry>
-		    <term><varname>fcrondeny</varname>=<replaceable>file-path</replaceable> 
-(<filename>&etc;/&fcron.deny;</filename>)</term>
-		    <listitem>
-			<para>Location of fcron.deny file.</para>
-		    </listitem>
-		</varlistentry>
-		<varlistentry>
-		    <term><varname>shell</varname>=<replaceable>file-path</replaceable> 
-(<filename>&shell;</filename>)</term>
-		    <listitem>
-			<para>Location of default shell called by &fcron; when
-running a job. When &fcron; runs a job, &fcron; uses the value of <envar>SHELL</envar> from the fcrontab if any, otherwise it uses the value from <filename>fcron.conf</filename> if any, or in last resort the value from <filename>/etc/passwd</filename>.</para>
-		    </listitem>
-		</varlistentry>
-		<varlistentry>
-		    <term><varname>sendmail</varname>=<replaceable>file-path</replaceable> 
-(<filename>&sendmail;</filename>)</term>
-		    <listitem>
-			<para>Location of mailer program called by &fcron; to
-send job output.</para>
-		    </listitem>
-		</varlistentry>
-		<varlistentry>
-		    <term><varname>editor</varname>=<replaceable>file-path</replaceable> 
-(<filename>&editor;</filename>)</term>
-		    <listitem>
-			<para>Location of default editor used when invoking
-"fcrontab -e".</para>
-		    </listitem>
-		</varlistentry>
-	    </variablelist> File-paths and directories are complete and absolute
-(i.e. beginning by a "/").</para>
-	<para>To run several instances of &fcron; simultaneously on the same
-system, you must use a different configuration file for each instance. Each
-instance must have a different <varname>fcrontabs</varname>,
-<varname>pidfile</varname> and <varname>fifofile</varname>. Then, use <link
-linkend="fcron.8">&fcron;</link>(8)'s command line option
-<parameter>-c</parameter> to select which config file (so which instance) you
-refer to.</para>
-    </refsect1>
+	<refsect1>
+		<title>Description</title>
+		<abstract>
+			<para>
+				This page describes the syntax used for the configuration file
+				of <link linkend="fcrontab.1">&fcrontab;</link>(1),
+				<link linkend="fcrondyn.1">&fcrondyn;</link>(1) and
+				<link linkend="fcron.8">&fcron;</link>(8).
+			</para>
+		</abstract>
+		<para>
+			Blank lines, line beginning by a hash sign (#) (which are
+			considered comments), leading blanks and tabs are ignored. Each line in a
+			&fcron.conf; file is of the form
+			<blockquote>
+				<para>name = value</para>
+			</blockquote>
+			where the blanks around equal-sign (=) are ignored and
+			optional. Trailing blanks are also ignored.
+		</para>
+		<para>
+			The following names are recognized (default value in parentheses):
+			<variablelist>
+				<title>Valid variables in a fcron.conf file</title>
+				<varlistentry>
+					<term>
+						<varname>fcrontabs</varname>=<replaceable>directory</replaceable>
+						(<filename>&fcrontabsdir;</filename>)
+					</term>
+					<listitem>
+						<para>&Fcron; spool directory.</para>
+					</listitem>
+				</varlistentry>
+				<varlistentry>
+					<term>
+						<varname>pidfile</varname>=<replaceable>file-path</replaceable>
+						(<filename>&fcron.pid;</filename>)
+					</term>
+					<listitem>
+						<para>
+							Location of &fcron; pid file (needed by &fcrontab;
+							to work properly).
+						</para>
+					</listitem>
+				</varlistentry>
+				<varlistentry>
+					<term>
+						<varname>suspendfile</varname>=<replaceable>file-path</replaceable>
+						(<filename>&suspendfile;</filename>)</term>
+					<listitem>
+						<para>
+							Location of &fcron; suspend file. On non-Linux
+							systems, this should be used to let fcron know how
+							long the system was suspended (to memory or disk),
+							so as task schedules can be updated accordingly.
+						</para>
+					</listitem>
+				</varlistentry>
+				<varlistentry>
+					<term>
+						<varname>fifofile</varname>=<replaceable>file-path</replaceable>
+						(<filename>&fcron.fifo;</filename>)
+					</term>
+					<listitem>
+						<para>
+							Location of &fcron; fifo file (needed by
+							&fcrondyn; to communicate with &fcron;).
+						</para>
+					</listitem>
+				</varlistentry>
+				<varlistentry>
+					<term>
+						<varname>fcronallow</varname>=<replaceable>file-path</replaceable>
+						(<filename>&etc;/&fcron.allow;</filename>)
+					</term>
+					<listitem>
+						<para>Location of fcron.allow file.</para>
+					</listitem>
+				</varlistentry>
+				<varlistentry>
+					<term>
+						<varname>fcrondeny</varname>=<replaceable>file-path</replaceable>
+						(<filename>&etc;/&fcron.deny;</filename>)
+					</term>
+					<listitem>
+						<para>Location of fcron.deny file.</para>
+					</listitem>
+				</varlistentry>
+				<varlistentry>
+					<term>
+						<varname>shell</varname>=<replaceable>file-path</replaceable>
+						(<filename>&shell;</filename>)
+					</term>
+					<listitem>
+						<para>
+							Location of default shell called by &fcron; when
+							running a job. When &fcron; runs a job, &fcron;
+							uses the value of <envar>SHELL</envar> from the
+							fcrontab if any, otherwise it uses the value from
+							<filename>fcron.conf</filename> if any, or in last
+							resort the value from
+							<filename>/etc/passwd</filename>.
+						</para>
+					</listitem>
+				</varlistentry>
+				<varlistentry>
+					<term>
+						<varname>sendmail</varname>=<replaceable>file-path</replaceable>
+						(<filename>&sendmail;</filename>)
+					</term>
+					<listitem>
+						<para>
+							Location of mailer program called by &fcron; to
+							send job output.
+						</para>
+					</listitem>
+				</varlistentry>
+				<varlistentry>
+					<term>
+						<varname>editor</varname>=<replaceable>file-path</replaceable>
+						(<filename>&editor;</filename>)
+					</term>
+					<listitem>
+						<para>
+							Location of default editor used when invoking
+							"fcrontab -e".
+						</para>
+					</listitem>
+				</varlistentry>
+				<varlistentry>
+					<term>
+						<varname>displayname</varname>=<replaceable>string</replaceable>
+						(<option>&displayname;</option>)
+					</term>
+					<listitem>
+						<para>
+							Display name for the "From: " header of mails sent
+							by us. N.B. &fcron has been following Vixie cron's
+							default email header format which is not fully
+							compliant with RFC 5322 (see <ulink
+							url="https://github.com/yo8192/fcron/issues/15">Issue
+							#15 </ulink>).  During this transition phase, to
+							achieve full RFC compliance, you may set a display
+							name. Leaving it empty will preserve the old
+							behavior.
+						</para>
+					</listitem>
+				</varlistentry>
+			</variablelist>
+			File-paths and directories are complete and absolute
+			(i.e. beginning by a "/").
+		</para>
+		<para>
+			To run several instances of &fcron; simultaneously on the same
+			system, you must use a different configuration file for each
+			instance. Each instance must have a different
+			<varname>fcrontabs</varname>, <varname>pidfile</varname> and
+			<varname>fifofile</varname>. Then, use <link
+			linkend="fcron.8">&fcron;</link>(8)'s command line option
+			<parameter>-c</parameter> to select which config file (so which
+			instance) you refer to.
+		</para>
+	</refsect1>
 
-    <refsect1>
-	<title>Files</title>
-	<variablelist>
-	    <varlistentry>
-		<term><filename>&etc;/&fcron.conf.location;</filename></term>
-		<listitem>
-		    <para>Configuration file for &fcron;, &fcrontab; and
-&fcrondyn;: contains paths (spool dir, pid file) and default programs to use
-(editor, shell, etc). See <link linkend="fcron.conf.5">&fcron.conf;</link>(5) for
-more details.</para>
-		</listitem>
-	    </varlistentry>
-	    <varlistentry>
-		<term><filename>&etc;/&fcron.allow;</filename></term>
-		<listitem>
-		    <para>Users allowed to use &fcrontab; and &fcrondyn; (one
-name per line, special name "all" acts for everyone)</para>
-		</listitem>
-	    </varlistentry>
-	    <varlistentry>
-		<term><filename>&etc;/&fcron.deny;</filename></term>
-		<listitem>
-		    <para>Users who are not allowed to use &fcrontab; and
-&fcrondyn; (same format as allow file)</para>
-		</listitem>
-	    </varlistentry>
-	    <varlistentry>
-		<term><filename>&etc;/pam.d/fcron</filename> (or
-<filename>&etc;/pam.conf</filename>)</term>
-		<listitem>
-		    <para><productname>PAM</productname> configuration file for
-&fcron;. Take a look at &pam;(8) for more details.</para>
-		</listitem>
-	    </varlistentry>
-	</variablelist>
-    </refsect1>
+	<refsect1>
+		<title>Files</title>
+		<variablelist>
+			<varlistentry>
+				<term><filename>&etc;/&fcron.conf.location;</filename></term>
+				<listitem>
+					<para>
+						Configuration file for &fcron;, &fcrontab; and
+						&fcrondyn;: contains paths (spool dir, pid file) and
+						default programs to use (editor, shell, etc). See
+						<link linkend="fcron.conf.5">&fcron.conf;</link>(5)
+						for more details.
+					</para>
+				</listitem>
+			</varlistentry>
+			<varlistentry>
+				<term><filename>&etc;/&fcron.allow;</filename></term>
+				<listitem>
+					<para>Users allowed to use &fcrontab; and &fcrondyn; (one
+						name per line, special name "all" acts for everyone)</para>
+				</listitem>
+			</varlistentry>
+			<varlistentry>
+				<term><filename>&etc;/&fcron.deny;</filename></term>
+				<listitem>
+					<para>
+						Users who are not allowed to use &fcrontab; and
+						&fcrondyn; (same format as allow file)
+					</para>
+				</listitem>
+			</varlistentry>
+			<varlistentry>
+				<term><filename>&etc;/pam.d/fcron</filename> (or
+					<filename>&etc;/pam.conf</filename>)</term>
+				<listitem>
+					<para>
+						<productname>PAM</productname> configuration file for
+						&fcron;. Take a look at &pam;(8) for more details.
+					</para>
+				</listitem>
+			</varlistentry>
+		</variablelist>
+	</refsect1>
 
-    &manpage-foot;
+	&manpage-foot;
 
 </refentry>
 

--- a/doc/fcron-doc.mod.in
+++ b/doc/fcron-doc.mod.in
@@ -42,6 +42,7 @@
 <!ENTITY sysfcrontab "@@SYSFCRONTAB@">
 <!ENTITY rootname "@@ROOTNAME@">
 <!ENTITY rootgroup "@@ROOTGROUP@">
+<!ENTITY displayname "@@DISPLAYNAME@">
 
 <!-- shortcuts -->
 

--- a/fcronconf.c
+++ b/fcronconf.c
@@ -44,6 +44,7 @@ char *fcrondeny = NULL;
 char *shell = NULL;
 char *sendmail = NULL;
 char *editor = NULL;
+char *displayname = NULL;
 
 void
 init_conf(void)
@@ -66,6 +67,7 @@ init_conf(void)
     sendmail = strdup2(SENDMAIL);
 #endif
     editor = strdup2(FCRON_EDITOR);
+    displayname = strdup2(DISPLAYNAME);
 }
 
 void
@@ -82,6 +84,7 @@ free_conf(void)
     Free_safe(shell);
     Free_safe(sendmail);
     Free_safe(editor);
+    Free_safe(displayname);
 }
 
 void
@@ -187,6 +190,9 @@ read_conf(void)
         }
         else if (strncmp(ptr1, "editor", namesize) == 0) {
             Set(editor, ptr2);
+        }
+        else if (strncmp(ptr1, "displayname", namesize) == 0) {
+            Set(displayname, ptr2);
         }
         else
             error("Unknown var name at line %s : line ignored", buf);

--- a/fcronconf.h
+++ b/fcronconf.h
@@ -39,6 +39,7 @@ extern char *fifofile;
 extern char *editor;
 extern char *shell;
 extern char *sendmail;
+extern char *displayname;
 /* end of global variables */
 
 /* functions prototypes */

--- a/fcronconf.h
+++ b/fcronconf.h
@@ -25,6 +25,10 @@
 #ifndef __FCRONCONF_H__
 #define __FCRONCONF_H__
 
+/* RFC5322's special mailbox address charcters */
+#define DQUOTE '\"'
+#define BSLASH '\\'
+#define SPECIAL_MBOX_CHARS "()<>[].,:;@\"\\"
 
 /* global variables */
 

--- a/fcrondyn_svr.c
+++ b/fcrondyn_svr.c
@@ -1,5 +1,5 @@
 /*
- * FCRON - periodic command scheduler 
+ * FCRON - periodic command scheduler
  *
  *  Copyright 2000-2021 Thibault Godouet <fcron@free.fr>
  *
@@ -12,11 +12,11 @@
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
- * 
+ *
  *  You should have received a copy of the GNU General Public License
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- * 
+ *
  *  The GNU General Public License can also be found in the file
  *  `LICENSE' that comes with the fcron source distribution.
  */
@@ -251,7 +251,9 @@ auth_client_so_peercred(struct fcrondyn_cl *client)
      * Sets client->fcl_user on success, don't do anything on failure
      * so that the client stays unauthenticated */
 {
-    const int true = 1;
+    /* [@PR #17] renamed (previously called 'true') to avoid conflict with
+       stdbool */
+    const int value = 1;
     /* There is no ucred.h (or equivalent) on linux to define struct ucred (!!)
      * so we do it here */
 #if ! ( defined(HAVE_CRED_H) && defined(HAVE_UCRED_H) \
@@ -266,8 +268,8 @@ auth_client_so_peercred(struct fcrondyn_cl *client)
     socklen_t cred_size = sizeof(cred);
     struct passwd *p_entry = NULL;
 
-    setsockopt(client->fcl_sock_fd, SOL_SOCKET, SO_PASSCRED, &true,
-               sizeof(true));
+    setsockopt(client->fcl_sock_fd, SOL_SOCKET, SO_PASSCRED, &value,
+               sizeof(value));
     if (getsockopt
         (client->fcl_sock_fd, SOL_SOCKET, SO_PEERCRED, &cred,
          &cred_size) != 0) {
@@ -861,7 +863,7 @@ exe_cmd(struct fcrondyn_cl *client)
 void
 remove_connection(struct fcrondyn_cl **client, struct fcrondyn_cl *prev_client,
                   select_instance * si)
-/* close the connection, remove it from the list 
+/* close the connection, remove it from the list
 and make client points to the next entry */
 {
     debug("closing connection : fd : %d", (*client)->fcl_sock_fd);

--- a/fileconf.c
+++ b/fileconf.c
@@ -1,5 +1,5 @@
 /*
- * FCRON - periodic command scheduler 
+ * FCRON - periodic command scheduler
  *
  *  Copyright 2000-2021 Thibault Godouet <fcron@free.fr>
  *
@@ -12,11 +12,11 @@
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
- * 
+ *
  *  You should have received a copy of the GNU General Public License
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- * 
+ *
  *  The GNU General Public License can also be found in the file
  *  `LICENSE' that comes with the fcron source distribution.
  */
@@ -458,41 +458,43 @@ assign_option_string(char **var, char *value)
 }
 
 
+/* [@PR #17] renamed labels 'true' and 'false' to avoid conflict with
+   stdbool */
 char *
 get_bool(char *ptr, int *i)
     /* get a bool value : either true (1) or false (0)
      * return NULL on error */
 {
     if (*ptr == '1')
-        goto true;
+        goto conf_true;
     else if (*ptr == '0')
-        goto false;
+        goto conf_false;
     else if (strncmp(ptr, "true", 4) == 0) {
         ptr += 3;
-        goto true;
+        goto conf_true;
     }
     else if (strncmp(ptr, "yes", 3) == 0) {
         ptr += 2;
-        goto true;
+        goto conf_true;
     }
     else if (strncmp(ptr, "false", 5) == 0) {
         ptr += 4;
-        goto false;
+        goto conf_false;
     }
     else if (strncmp(ptr, "no", 2) == 0) {
         ptr += 1;
-        goto false;
+        goto conf_false;
     }
     else
         return NULL;
 
- true:
-    *i = 1;
+ conf_true:
+    *i = true;
     ptr++;
     return ptr;
 
- false:
-    *i = 0;
+ conf_false:
+    *i = false;
     ptr++;
     return ptr;
 
@@ -1423,7 +1425,7 @@ read_shortcut(char *ptr, cf_t * cf)
     }
 
     /* The next char must be a space (no other option allowed when using
-     * a shortcut: if the user wants to use options, they should use the 
+     * a shortcut: if the user wants to use options, they should use the
      * native fcron lines */
     if (!isspace((int)*ptr)) {
         fprintf(stderr, "%s:%d: No space after shortcut: skipping line.\n",
@@ -1674,7 +1676,7 @@ read_period(char *ptr, cf_t * cf)
     /* skip the % */
     ptr++;
 
-    /* a runfreq set to 1 means : this is a periodical line 
+    /* a runfreq set to 1 means : this is a periodical line
      * (runfreq cannot be changed by read_opt() if already set to 1) */
     cl->cl_remain = cl->cl_runfreq = 1;
 
@@ -2028,7 +2030,7 @@ read_field(char *ptr, bitstr_t * ary, int max, const char **names)
 
 void
 delete_file(const char *user_name)
-    /* free a file if user_name is not null 
+    /* free a file if user_name is not null
      *   otherwise free all files */
 {
     cf_t *file = NULL;

--- a/files/fcron.conf.in
+++ b/files/fcron.conf.in
@@ -24,6 +24,6 @@ sendmail	=	@@SENDMAIL@
 # Location of the default editor for "fcrontab -e"
 editor		=	@@FCRON_EDITOR@
 
-# Display name for the "From: " header of mails sent by us. Watch out! It
-# might cause rejections from picky SMTPDs.
+# Display name for the "From: " header of mails sent by us. Default is
+# unset/empty. Please read fcron.conf(5) before setting it!
 displayname =   @@DISPLAYNAME@

--- a/files/fcron.conf.in
+++ b/files/fcron.conf.in
@@ -25,5 +25,11 @@ sendmail	=	@@SENDMAIL@
 editor		=	@@FCRON_EDITOR@
 
 # Display name for the "From: " header of mails sent by us. Default is
-# unset/empty. Please read fcron.conf(5) before setting it!
+# unset/empty, which keeps the "From: " header as it was before this feature
+# was added -- not RFC5322-compliant, though. A sane RFC5322-compliant setting,
+# could be:
+#
+#   displayname = Fcron Deamon
+#
+# Please read fcron.conf(5) before setting it!
 displayname =   @@DISPLAYNAME@

--- a/files/fcron.conf.in
+++ b/files/fcron.conf.in
@@ -23,3 +23,7 @@ sendmail	=	@@SENDMAIL@
 
 # Location of the default editor for "fcrontab -e"
 editor		=	@@FCRON_EDITOR@
+
+# Display name for the "From: " header of mails sent by us. Watch out! It
+# might cause rejections from picky SMTPDs.
+displayname =   @@DISPLAYNAME@

--- a/global.h
+++ b/global.h
@@ -1,5 +1,5 @@
 /*
- * FCRON - periodic command scheduler 
+ * FCRON - periodic command scheduler
  *
  *  Copyright 2000-2021 Thibault Godouet <fcron@free.fr>
  *
@@ -12,18 +12,18 @@
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
- * 
+ *
  *  You should have received a copy of the GNU General Public License
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- * 
+ *
  *  The GNU General Public License can also be found in the file
  *  `LICENSE' that comes with the fcron source distribution.
  */
 
 
 
-/* 
+/*
    WARNING : this file should not be modified.
    Compilation's options are in config.h
 */
@@ -31,7 +31,7 @@
 #ifndef __GLOBAL_H__
 #define __GLOBAL_H__
 
-/* config.h must be included before every other includes 
+/* config.h must be included before every other includes
  * (contains the compilation options) */
 #include "config.h"
 
@@ -69,6 +69,7 @@
 #include <stdarg.h>
 #endif
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/job.c
+++ b/job.c
@@ -280,56 +280,56 @@ sig_dfl(void)
 #define DQUOTE '\"'
 #define BSLASH '\\'
 #define SPECIALS "()<>[].,:;@"
-#define MAIL_LINE_LEN 998 			/* RFC5322 */
+#define MAIL_LINE_LEN 998             /* RFC5322 */
 
 char *
 make_mailbox(char *displayname, char *mail_from, char *hostname)
-	/* Produce a "mailbox" header as per RFC5322 sec. 3.2.3
-	 * <https://datatracker.ietf.org/doc/html/rfc5322#section-3.2.3> */
+    /* Produce a "mailbox" header as per RFC5322 sec. 3.2.3
+     * <https://datatracker.ietf.org/doc/html/rfc5322#section-3.2.3> */
 {
-	char specials[sizeof(SPECIALS) + 2];
-	char need_quotes = 0, need_anglebrackets = 0;
-	char c = '\0';
-	char *bpos = NULL, *dpos = NULL;
-	char *buf1 = NULL, *buf2 = NULL;
+    char specials[sizeof(SPECIALS) + 2];
+    char need_quotes = 0, need_anglebrackets = 0;
+    char c = '\0';
+    char *bpos = NULL, *dpos = NULL;
+    char *buf1 = NULL, *buf2 = NULL;
 
-	snprintf(specials, sizeof(specials), "%s%c%c", SPECIALS, DQUOTE, BSLASH);
+    snprintf(specials, sizeof(specials), "%s%c%c", SPECIALS, DQUOTE, BSLASH);
 
-	/* This should actually be shorter 'cause the header name is prepended
-	 * downstream */
-	buf1 = (char *)calloc(MAIL_LINE_LEN+1, sizeof(char));
-	buf2 = (char *)calloc(MAIL_LINE_LEN+1, sizeof(char));
+    /* This should actually be shorter 'cause the header name is prepended
+     * downstream */
+    buf1 = (char *)calloc(MAIL_LINE_LEN+1, sizeof(char));
+    buf2 = (char *)calloc(MAIL_LINE_LEN+1, sizeof(char));
 
-	/* walk the displayname and rebuild it in buf1 */
-	dpos = displayname;
-	bpos = buf1;
-	while (*dpos) {
-		c = *dpos++;
-		if (strchr(specials, c)) {
-			/* insert escape */
-			if (c == DQUOTE) *bpos++ = BSLASH;
-			need_quotes = 1;
-		}
-		*bpos++ = c;
-	}
+    /* walk the displayname and rebuild it in buf1 */
+    dpos = displayname;
+    bpos = buf1;
+    while (*dpos) {
+        c = *dpos++;
+        if (strchr(specials, c)) {
+            /* insert escape */
+            if (c == DQUOTE) *bpos++ = BSLASH;
+            need_quotes = 1;
+        }
+        *bpos++ = c;
+    }
 
-	need_anglebrackets = strlen(buf1) > 0;
+    need_anglebrackets = strlen(buf1) > 0;
 
-	if (need_quotes)
-		snprintf(buf2, MAIL_LINE_LEN, "\"%s\"", buf1);
-	else
-		buf2 = strncpy(buf2, buf1, MAIL_LINE_LEN);
+    if (need_quotes)
+        snprintf(buf2, MAIL_LINE_LEN, "\"%s\"", buf1);
+    else
+        buf2 = strncpy(buf2, buf1, MAIL_LINE_LEN);
 
-	/* no @ here, it's handled upstream */
-	if (need_anglebrackets)
-		snprintf(buf1, MAIL_LINE_LEN, "%s %c%s%s%c",
-				 buf2, '<', mail_from, hostname, '>');
-	else
-		snprintf(buf1, MAIL_LINE_LEN, "%s%s", mail_from, hostname);
+    /* no @ here, it's handled upstream */
+    if (need_anglebrackets)
+        snprintf(buf1, MAIL_LINE_LEN, "%s %c%s%s%c",
+                 buf2, '<', mail_from, hostname, '>');
+    else
+        snprintf(buf1, MAIL_LINE_LEN, "%s%s", mail_from, hostname);
 
-	Free_safe(buf2);
+    Free_safe(buf2);
 
-	return buf1;
+    return buf1;
 }
 
 FILE *
@@ -375,7 +375,7 @@ create_mail(cl_t * line, char *subject, char *content_type, char *encoding,
 
     /* write mail header. displayname comes from fcron.conf */
     fprintf(mailf, "From: %s\n",
-			make_mailbox(displayname, mailfrom, hostname_from));
+            make_mailbox(displayname, mailfrom, hostname_from));
 
     fprintf(mailf, "To: %s%s\n", line->cl_mailto, hostname_to);
 

--- a/job.c
+++ b/job.c
@@ -1,5 +1,5 @@
 /*
- * FCRON - periodic command scheduler 
+ * FCRON - periodic command scheduler
  *
  *  Copyright 2000-2021 Thibault Godouet <fcron@free.fr>
  *
@@ -12,11 +12,11 @@
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
- * 
+ *
  *  You should have received a copy of the GNU General Public License
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- * 
+ *
  *  The GNU General Public License can also be found in the file
  *  `LICENSE' that comes with the fcron source distribution.
  */
@@ -318,8 +318,9 @@ create_mail(cl_t * line, char *subject, char *content_type, char *encoding,
     hostname[0] = '\0';
 #endif                          /* HAVE_GETHOSTNAME */
 
-    /* write mail header */
-    fprintf(mailf, "From: %s%s (fcron)\n", mailfrom, hostname_from);
+    /* write mail header. displayname comes from fcron.conf */
+    fprintf(mailf, "From: %s %s%s\n", displayname != NULL ? displayname : "",
+            mailfrom, hostname_from);
     fprintf(mailf, "To: %s%s\n", line->cl_mailto, hostname_to);
 
     if (subject)
@@ -447,7 +448,7 @@ read_write_pipe(int fd, void *buf, size_t size, int action)
 
 int
 read_pipe(int fd, void *buf, size_t size)
-    /* Read data from pipe. 
+    /* Read data from pipe.
      * Handles signal interruptions, and read in several passes.
      * Returns ERR in case of a closed pipe, the errno from read
      * for other errors, and OK if everything was read successfully */
@@ -457,7 +458,7 @@ read_pipe(int fd, void *buf, size_t size)
 
 int
 write_pipe(int fd, void *buf, size_t size)
-    /* Read data from pipe. 
+    /* Read data from pipe.
      * Handles signal interruptions, and read in several passes.
      * Returns ERR in case of a closed pipe, the errno from write
      * for other errors, and OK if everything was read successfully */

--- a/job.c
+++ b/job.c
@@ -27,6 +27,7 @@
 #include "job.h"
 #include "temp_file.h"
 
+
 void sig_dfl(void);
 void end_job(cl_t * line, int status, FILE * mailf, short mailpos,
              char **sendmailenv);
@@ -276,6 +277,60 @@ sig_dfl(void)
     signal(SIGPIPE, SIG_DFL);
 }
 
+#define DQUOTE '\"'
+#define BSLASH '\\'
+#define SPECIALS "()<>[].,:;@"
+#define MAIL_LINE_LEN 998 			/* RFC5322 */
+
+char *
+make_mailbox(char *displayname, char *mail_from, char *hostname)
+	/* Produce a "mailbox" header as per RFC5322 sec. 3.2.3
+	 * <https://datatracker.ietf.org/doc/html/rfc5322#section-3.2.3> */
+{
+	char specials[sizeof(SPECIALS) + 2];
+	char need_quotes = 0, need_anglebrackets = 0;
+	char c = '\0';
+	char *bpos = NULL, *dpos = NULL;
+	char *buf1 = NULL, *buf2 = NULL;
+
+	snprintf(specials, sizeof(specials), "%s%c%c", SPECIALS, DQUOTE, BSLASH);
+
+	/* This should actually be shorter 'cause the header name is prepended
+	 * downstream */
+	buf1 = (char *)calloc(MAIL_LINE_LEN+1, sizeof(char));
+	buf2 = (char *)calloc(MAIL_LINE_LEN+1, sizeof(char));
+
+	/* walk the displayname and rebuild it in buf1 */
+	dpos = displayname;
+	bpos = buf1;
+	while (*dpos) {
+		c = *dpos++;
+		if (strchr(specials, c)) {
+			/* insert escape */
+			if (c == DQUOTE) *bpos++ = BSLASH;
+			need_quotes = 1;
+		}
+		*bpos++ = c;
+	}
+
+	need_anglebrackets = strlen(buf1) > 0;
+
+	if (need_quotes)
+		snprintf(buf2, MAIL_LINE_LEN, "\"%s\"", buf1);
+	else
+		buf2 = strncpy(buf2, buf1, MAIL_LINE_LEN);
+
+	/* no @ here, it's handled upstream */
+	if (need_anglebrackets)
+		snprintf(buf1, MAIL_LINE_LEN, "%s %c%s%s%c",
+				 buf2, '<', mail_from, hostname, '>');
+	else
+		snprintf(buf1, MAIL_LINE_LEN, "%s%s", mail_from, hostname);
+
+	Free_safe(buf2);
+
+	return buf1;
+}
 
 FILE *
 create_mail(cl_t * line, char *subject, char *content_type, char *encoding,
@@ -319,8 +374,9 @@ create_mail(cl_t * line, char *subject, char *content_type, char *encoding,
 #endif                          /* HAVE_GETHOSTNAME */
 
     /* write mail header. displayname comes from fcron.conf */
-    fprintf(mailf, "From: %s %s%s\n", displayname != NULL ? displayname : "",
-            mailfrom, hostname_from);
+    fprintf(mailf, "From: %s\n",
+			make_mailbox(displayname, mailfrom, hostname_from));
+
     fprintf(mailf, "To: %s%s\n", line->cl_mailto, hostname_to);
 
     if (subject)

--- a/job.h
+++ b/job.h
@@ -1,5 +1,5 @@
 /*
- * FCRON - periodic command scheduler 
+ * FCRON - periodic command scheduler
  *
  *  Copyright 2000-2021 Thibault Godouet <fcron@free.fr>
  *
@@ -12,11 +12,11 @@
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
- * 
+ *
  *  You should have received a copy of the GNU General Public License
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- * 
+ *
  *  The GNU General Public License can also be found in the file
  *  `LICENSE' that comes with the fcron source distribution.
  */
@@ -24,6 +24,8 @@
 
 #ifndef __JOB_H__
 #define __JOB_H__
+
+#define MAIL_LINE_LEN_MAX 998 /* RFC5322's max line length */
 
 /* functions prototypes */
 extern void change_user_setup_env(struct cl_t *cl, char ***sendmailenv,

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -1,0 +1,20 @@
+# Prototype makefile, while waiting for integration of a test framework
+SRCDIR		:= ..
+
+SRCST := mailbox_addr.c
+OBJST := $(patsubst %.c,%.o,$(SRCST))
+EXEST := $(patsubst %.c,%,$(SRCST))
+
+OBJSD := $(addprefix $(SRCDIR)/,log.o job.o mem.o filesubs.o subs.o fcronconf.o temp_file.o env_list.o u_list.o)
+
+
+.PHONY: clean tests
+
+CFLAGS += -I$(SRCDIR)
+
+tests: $(OBJSD)
+	$(CC) $(CFLAGS) $(OBJSD) $(LIBS) $(SRCST) -o $(EXEST)
+	./$(EXEST)
+
+clean:
+	rm -f *.o core $(EXEST)

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -1,16 +1,14 @@
 # Prototype makefile, while waiting for integration of a test framework
-SRCDIR		:= ..
-
-SRCST := mailbox_addr.c
-OBJST := $(patsubst %.c,%.o,$(SRCST))
-EXEST := $(patsubst %.c,%,$(SRCST))
-
-OBJSD := $(addprefix $(SRCDIR)/,log.o job.o mem.o filesubs.o subs.o fcronconf.o temp_file.o env_list.o u_list.o)
-
-
-.PHONY: clean tests
+SRCDIR := ..
+LIBS   := @LIBS@
+SRCST  := mailbox_addr.c
+OBJST  := $(patsubst %.c,%.o,$(SRCST))
+EXEST  := $(patsubst %.c,%,$(SRCST))
+OBJSD  := $(addprefix $(SRCDIR)/,log.o job.o mem.o filesubs.o subs.o fcronconf.o temp_file.o env_list.o u_list.o)
 
 CFLAGS += -I$(SRCDIR)
+
+.PHONY: clean tests
 
 tests: $(OBJSD)
 	$(CC) $(CFLAGS) $(OBJSD) $(LIBS) $(SRCST) -o $(EXEST)

--- a/test/mailbox_addr.c
+++ b/test/mailbox_addr.c
@@ -1,0 +1,139 @@
+/* Prototype test harness, while waiting for integration of a test framework */
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include "fcron.h"
+#include "job.h"
+#include "fcronconf.h"
+
+#define dasserteq(DESCR, RETURNED, EXPECTED) \
+{ \
+    printf("%s: %ld ?= %ld\n", (DESCR), (long)(RETURNED), (long)(EXPECTED)); \
+    assert((RETURNED) == (EXPECTED));                      \
+}
+
+#define dassertcmp(DESCR, RETURNED, EXPECTED) \
+{ \
+    printf("%s: %s ?= %s\n", (DESCR), (RETURNED), (EXPECTED));   \
+    assert(!strcmp((RETURNED), (EXPECTED)));                      \
+}
+
+
+/* These globals should maybe come from a lib instead of the various exes? */
+char *prog_name = NULL;
+pid_t daemon_pid = 0;
+char foreground = 1;
+char default_mail_charset[TERM_LEN] = "";
+pam_handle_t *pamh = NULL;
+const struct pam_conv apamconv = { NULL };
+mode_t saved_umask;
+uid_t rootuid = 0;
+char *tmp_path = "";
+
+char *format_displayname(char *displayname);
+char *make_mailbox_addr(char *displayname, char *mail_from, char *hostname);
+
+
+void _test(char *pdescr, char *displayname, char *mailfrom, char *hostname)
+{
+    char descr[2*LINE_LEN] = "";
+    char expected[2*LINE_LEN] = "";
+    char *qdisplayname = NULL, *mailbox=NULL;
+
+    qdisplayname = format_displayname(displayname);
+    sprintf(descr, "format_displayname: %s", pdescr);
+    dassertcmp(descr, qdisplayname, displayname);
+
+    if (strlen(displayname))
+        snprintf(expected, sizeof(expected), "%s <%s%s>",
+                 qdisplayname, mailfrom, hostname);
+    else
+        snprintf(expected, sizeof(expected), "%s%s", mailfrom, hostname);
+
+    mailbox = make_mailbox_addr(qdisplayname, mailfrom, hostname);
+    sprintf(descr, "make_mailbox_addr: %s", pdescr);
+    dassertcmp(descr, mailbox, expected);
+
+    Free_safe(qdisplayname);
+    Free_safe(mailbox);
+}
+
+
+void _test_c(char *pdescr, char *mailfrom, char *hostname, char c)
+{
+    char descr[2*LINE_LEN];
+    char expected[2*LINE_LEN];
+    char displayname[LINE_LEN];
+    char *qdisplayname = NULL, *mailbox=NULL;
+
+    snprintf(displayname, sizeof(displayname), "Foo %c Bar", c);
+    if (c == DQUOTE)
+        snprintf(expected, sizeof(expected), "\"Foo %c%c Bar\"", BSLASH, c);
+    else
+        snprintf(expected, sizeof(expected), "\"%s\"", displayname);
+    qdisplayname = format_displayname(displayname);
+    sprintf(descr, "format_displayname: %s '%c'", pdescr, c);
+    dassertcmp(descr, qdisplayname, expected);
+
+    snprintf(expected, sizeof(expected), "%s <%s%s>", qdisplayname, mailfrom, hostname);
+    mailbox = make_mailbox_addr(qdisplayname, mailfrom, hostname);
+    sprintf(descr, "make_mailbox_addr: %s '%c'", pdescr, c);
+    dassertcmp(descr, mailbox, expected);
+
+    Free_safe(qdisplayname);
+    Free_safe(mailbox);
+}
+
+int main(int argc, char* argv[])
+{
+    char *displayname = NULL;
+    char *qdisplayname = NULL;
+    char *mailfrom=NULL;
+    char *hostname=NULL;
+    char *mailbox=NULL, *walker=NULL;
+    char c = '\0';
+
+    mailfrom = strdup2("baz");
+    hostname = strdup2("@quux");
+
+    displayname = strdup2("");
+    _test("empty displayname", displayname, mailfrom, hostname);
+
+    displayname = strdup2("Foo Bar");
+    _test("displayname with no special char", displayname, mailfrom, hostname);
+
+    walker = SPECIAL_MBOX_CHARS;
+    while (*walker) {
+        c = *walker++;
+        _test_c("displayname with special char", mailfrom, hostname, c);
+	}
+
+    /* overflow tests */
+    displayname = (char *)realloc_safe(displayname,
+                                       LINE_LEN + 1 * sizeof(char),
+                                       "displayname buffer");
+    memset(displayname, 'a', LINE_LEN);
+    displayname[LINE_LEN] = '\0';
+    displayname[0] = DQUOTE;
+
+    qdisplayname = format_displayname(displayname);
+    dasserteq("format_displayname: overflow", qdisplayname, NULL);
+
+    mailbox = make_mailbox_addr(displayname, mailfrom, hostname);
+    dasserteq("make_mailbox_addr: overflow", mailbox, NULL);
+
+    Free_safe(mailbox);
+    Free_safe(hostname);
+    Free_safe(mailfrom);
+    Free_safe(displayname);
+    Free_safe(qdisplayname);
+
+    return 0;
+}
+
+/* Local Variables:  */
+/* mode: c           */
+/* indent-tabs-mode: nil */
+/* End:              */

--- a/test/mailbox_addr.c
+++ b/test/mailbox_addr.c
@@ -11,15 +11,8 @@
 #define dasserteq(DESCR, RETURNED, EXPECTED) \
 { \
     printf("%s: %ld ?= %ld\n", (DESCR), (long)(RETURNED), (long)(EXPECTED)); \
-    assert((RETURNED) == (EXPECTED));                      \
+    assert((RETURNED) == (EXPECTED)); \
 }
-
-#define dassertcmp(DESCR, RETURNED, EXPECTED) \
-{ \
-    printf("%s: %s ?= %s\n", (DESCR), (RETURNED), (EXPECTED));   \
-    assert(!strcmp((RETURNED), (EXPECTED)));                      \
-}
-
 
 /* These globals should maybe come from a lib instead of the various exes? */
 char *prog_name = NULL;
@@ -36,79 +29,79 @@ char *format_displayname(char *displayname);
 char *make_mailbox_addr(char *displayname, char *mail_from, char *hostname);
 
 
-void _test(char *pdescr, char *displayname, char *mailfrom, char *hostname)
+void _test_format_displayname(char *test_desc, char *arg, char *expected)
 {
-    char descr[2*LINE_LEN] = "";
-    char expected[2*LINE_LEN] = "";
-    char *qdisplayname = NULL, *mailbox=NULL;
+    char *output = NULL;
 
-    qdisplayname = format_displayname(displayname);
-    sprintf(descr, "format_displayname: %s", pdescr);
-    dassertcmp(descr, qdisplayname, displayname);
-
-    if (strlen(displayname))
-        snprintf(expected, sizeof(expected), "%s <%s%s>",
-                 qdisplayname, mailfrom, hostname);
-    else
-        snprintf(expected, sizeof(expected), "%s%s", mailfrom, hostname);
-
-    mailbox = make_mailbox_addr(qdisplayname, mailfrom, hostname);
-    sprintf(descr, "make_mailbox_addr: %s", pdescr);
-    dassertcmp(descr, mailbox, expected);
-
-    Free_safe(qdisplayname);
-    Free_safe(mailbox);
+    output = format_displayname(arg);
+    printf("%s: format_displayname('%s'): '%s' ?= '%s'\n",
+           test_desc, arg, output, expected);
+    assert(strcmp(output, expected) == 0);
+    Free_safe(output);
 }
 
 
-void _test_c(char *pdescr, char *mailfrom, char *hostname, char c)
+void _test_make_mailbox_addr(char *test_desc, char *displayname,
+                             char *mailfrom, char *hostname, char *expected)
 {
-    char descr[2*LINE_LEN];
-    char expected[2*LINE_LEN];
-    char displayname[LINE_LEN];
-    char *qdisplayname = NULL, *mailbox=NULL;
+    char *output = NULL;
 
-    snprintf(displayname, sizeof(displayname), "Foo %c Bar", c);
-    if (c == DQUOTE)
-        snprintf(expected, sizeof(expected), "\"Foo %c%c Bar\"", BSLASH, c);
-    else
-        snprintf(expected, sizeof(expected), "\"%s\"", displayname);
-    qdisplayname = format_displayname(displayname);
-    sprintf(descr, "format_displayname: %s '%c'", pdescr, c);
-    dassertcmp(descr, qdisplayname, expected);
-
-    snprintf(expected, sizeof(expected), "%s <%s%s>", qdisplayname, mailfrom, hostname);
-    mailbox = make_mailbox_addr(qdisplayname, mailfrom, hostname);
-    sprintf(descr, "make_mailbox_addr: %s '%c'", pdescr, c);
-    dassertcmp(descr, mailbox, expected);
-
-    Free_safe(qdisplayname);
-    Free_safe(mailbox);
+    output = make_mailbox_addr(displayname, mailfrom, hostname);
+    printf("%s: make_mailbox_addr('%s', '%s', '%s'): '%s' ?= '%s'\n",
+           test_desc, displayname, mailfrom, hostname, output, expected);
+    assert(strcmp(output, expected) == 0);
+    Free_safe(output);
 }
 
 int main(int argc, char* argv[])
 {
     char *displayname = NULL;
-    char *qdisplayname = NULL;
-    char *mailfrom=NULL;
-    char *hostname=NULL;
-    char *mailbox=NULL, *walker=NULL;
-    char c = '\0';
+    char *output = NULL;
 
-    mailfrom = strdup2("baz");
-    hostname = strdup2("@quux");
+    /* Mind that format_displayname() might modify input displayname, thus all
+       special characters must be tested */
+    _test_format_displayname("empty displayname", "", "");
+    _test_format_displayname("displayname with no special char",
+                             "Foo Bar", "Foo Bar");
+    _test_format_displayname("displayname with no special char",
+                             "Foo'Bar", "Foo'Bar");
 
-    displayname = strdup2("");
-    _test("empty displayname", displayname, mailfrom, hostname);
+    /* Make sure to extend this series, should SPECIAL_MBOX_CHARS change. All
+       those require quoting */
+    _test_format_displayname("displayname with special char",
+                             "(Foo Bar", "\"(Foo Bar\"");
+    _test_format_displayname("displayname with special char",
+                             "Foo Bar)", "\"Foo Bar)\"");
+    _test_format_displayname("displayname with special char",
+                             "Foo B<ar", "\"Foo B<ar\"");
+    _test_format_displayname("displayname with special char",
+                             "Fo>o Bar", "\"Fo>o Bar\"");
+    _test_format_displayname("displayname with special char",
+                             "F[oo Bar", "\"F[oo Bar\"");
+    _test_format_displayname("displayname with special char",
+                             "Foo] Bar", "\"Foo] Bar\"");
+    _test_format_displayname("displayname with special char",
+                             "Foo . Bar", "\"Foo . Bar\"");
+    _test_format_displayname("displayname with special char",
+                             "Foo, Bar", "\"Foo, Bar\"");
+    _test_format_displayname("displayname with special char",
+                             "Foo B:ar", "\"Foo B:ar\"");
+    _test_format_displayname("displayname with special char",
+                             "Foo ;Bar", "\"Foo ;Bar\"");
+    _test_format_displayname("displayname with special char",
+                             "Foo@Bar", "\"Foo@Bar\"");
+    _test_format_displayname("displayname with double quote",
+                             "Foo \" Bar", "\"Foo \\\" Bar\"");
+    _test_format_displayname("displayname with backslash",
+                             "Foo \\Bar", "\"Foo \\Bar\"");
 
-    displayname = strdup2("Foo Bar");
-    _test("displayname with no special char", displayname, mailfrom, hostname);
+    /* make_mailbox_addr() only composes the "mailbox" address header: it's
+       agnostic of any special character */
+    _test_make_mailbox_addr("empty displayname => no angle brackets",
+                            "", "baz", "@quux", "baz@quux");
+    _test_make_mailbox_addr("displayname => needs angle brackets",
+                            "Foo Bar", "baz", "@quux", "Foo Bar <baz@quux>");
 
-    walker = SPECIAL_MBOX_CHARS;
-    while (*walker) {
-        c = *walker++;
-        _test_c("displayname with special char", mailfrom, hostname, c);
-	}
 
     /* overflow tests */
     displayname = (char *)realloc_safe(displayname,
@@ -118,17 +111,15 @@ int main(int argc, char* argv[])
     displayname[LINE_LEN] = '\0';
     displayname[0] = DQUOTE;
 
-    qdisplayname = format_displayname(displayname);
-    dasserteq("format_displayname: overflow", qdisplayname, NULL);
+    output = format_displayname(displayname);
+    dasserteq("format_displayname: overflow", output, NULL);
+    Free_safe(output);
 
-    mailbox = make_mailbox_addr(displayname, mailfrom, hostname);
-    dasserteq("make_mailbox_addr: overflow", mailbox, NULL);
+    output = make_mailbox_addr(displayname, "baz", "@quux");
+    dasserteq("make_mailbox_addr: overflow", output, NULL);
+    Free_safe(output);
 
-    Free_safe(mailbox);
-    Free_safe(hostname);
-    Free_safe(mailfrom);
     Free_safe(displayname);
-    Free_safe(qdisplayname);
 
     return 0;
 }


### PR DESCRIPTION
I made an attempt at a configurable "displayname" string to be used in the "From:" header of outgoing e-mails. This should fix Issue #15. So, one should be able to configure

    displayname = "(fcron)"  # empty by default

and get a "From:" header like

    From: (fcron) <your-adress@your-domain>

instead of the original problematic one

    From: <your-adress@your-domain> (fcron)

Be warned that I couldn't test it as the build is a bit shaky on my Gentoo box.