### PR TITLE
fcrondyn: include seconds in fcrondyn -x ls as "YYYY-mm-dd HH:MM:SS"

### DIFF
--- a/fcrondyn_svr.c
+++ b/fcrondyn_svr.c
@@ -455,9 +455,10 @@ print_line(int fd, struct cl_t *line, unsigned char *details, pid_t pid,
             ftime = localtime(&until);
             len +=
                 snprintf(buf + len, sizeof(buf) - len,
-                         " %04d-%02d-%02d %02d:%02d %s",
+                         " %04d-%02d-%02d %02d:%02d:%02d %s",
                          (ftime->tm_year + 1900), (ftime->tm_mon + 1),
                          ftime->tm_mday, ftime->tm_hour, ftime->tm_min,
+                         ftime->tm_sec,
                          (is_strict(line->cl_option)) ? "Y" : "N");
         }
         else
@@ -468,9 +469,9 @@ print_line(int fd, struct cl_t *line, unsigned char *details, pid_t pid,
     if (bit_test(details, FIELD_SCHEDULE)) {
         ftime = localtime(&(line->cl_nextexe));
         len +=
-            snprintf(buf + len, sizeof(buf) - len, "|%04d-%02d-%02d %02d:%02d",
+            snprintf(buf + len, sizeof(buf) - len, "|%04d-%02d-%02d %02d:%02d:%02d",
                      (ftime->tm_year + 1900), (ftime->tm_mon + 1),
-                     ftime->tm_mday, ftime->tm_hour, ftime->tm_min);
+                     ftime->tm_mday, ftime->tm_hour, ftime->tm_min, ftime->tm_sec);
     }
     len += snprintf(buf + len, sizeof(buf) - len, "|%s\n", line->cl_shell);
 

--- a/fcrondyn_svr.c
+++ b/fcrondyn_svr.c
@@ -378,7 +378,7 @@ print_fields(int fd, unsigned char *details)
     char field_user[] = "|USER     ";
     char field_rq[] = "|R&Q ";
     char field_options[] = "|OPTIONS  ";
-    char field_schedule[] = "|SCHEDULE        ";
+    char field_schedule[] = "|SCHEDULE           ";
     char field_until[] = "|LAVG 1,5,15 UNTIL       STRICT";
     char field_pid[] = "|PID    ";
     char field_index[] = "|INDEX";


### PR DESCRIPTION
if there is second-precision in fcrontab, there should be second-precision in fcrondyn
```
wolke:~$ sudo fcrondyn -x ls
ID   |USER     |SCHEDULE           |CMD
18   |root     |2024-03-21 11:57:47|sudo backup --snapshot-src --ac=30 FIVEMIN home pix
19   |root     |2024-03-21 12:00:00|sudo backup --snapshot-src --ac=30 HOURLY home stuff pix mus
```