### PR TITLE
print Job with uppercase J when logging that a runonce job ran already

### DIFF
--- a/database.c
+++ b/database.c
@@ -540,12 +540,12 @@ wait_chld(void)
             if (pid == e->e_ctrl_pid) {
                 if (e->e_line == NULL) {
                     /* the corresponding file has been removed from memory */
-                    debug("job finished: pid %d", pid);
+                    debug("Job finished: pid %d", pid);
                 }
                 else {
 
                     line = e->e_line;
-/*  		    debug("job finished: %s", line->cl_shell); */
+/*  		    debug("Job finished: %s", line->cl_shell); */
                     line->cl_numexe -= 1;
                     line->cl_file->cf_running -= 1;
 
@@ -590,11 +590,11 @@ wait_all(int *counter)
             if (pid == e->e_ctrl_pid) {
                 if (e->e_line == NULL) {
                     /* the corresponding file has been removed from memory */
-                    debug("job finished: pid %d", pid);
+                    debug("Job finished: pid %d", pid);
                 }
                 else {
 
-                    debug("job finished: '%s'", e->e_line->cl_shell);
+                    debug("Job finished: '%s'", e->e_line->cl_shell);
                     e->e_line->cl_numexe -= 1;
                     e->e_line->cl_file->cf_running -= 1;
 
@@ -1438,7 +1438,7 @@ set_next_exe_startup(struct cl_t *cl, const int context,
         else {
             /* job has been stopped during execution :
              * launch it again */
-            warn("job '%s' did not finish : running it again.", cl->cl_shell);
+            warn("Job '%s' did not finish : running it again.", cl->cl_shell);
             set_serial_once(cl->cl_option);
             add_serial_job(cl, -1);
         }

--- a/database.c
+++ b/database.c
@@ -1453,7 +1453,7 @@ set_next_exe_startup(struct cl_t *cl, const int context,
     if (is_runonce(cl->cl_option) && is_hasrun(cl->cl_option)) {
         /* if we get here, then context != CONTEXT_BOOT and_volatile is false */
         /* do nothing: don't re-schedule or add to the job queue */
-        explain("job '%s' with runonce set has already run since last "
+        explain("Job '%s' with runonce set has already run since last "
                 "system startup: not re-scheduling.", cl->cl_shell);
     }
     else if (is_td(cl->cl_option)) {

--- a/fcrondyn_svr.c
+++ b/fcrondyn_svr.c
@@ -606,7 +606,7 @@ cmd_ls(struct fcrondyn_cl *client, long int *cmd, int fd, int is_root)
                  e = exe_list_next(exe_list)) {
                 if (e->e_line == NULL) {
                     if (is_root) {
-                        send_msg_fd(fd, "job no more in an fcrontab: pid %d",
+                        send_msg_fd(fd, "Job no more in an fcrontab: pid %d",
                                     e->e_job_pid);
                         found = 1;
                     }


### PR DESCRIPTION
In other log messages, Job is written with uppercase j.
Adjust this log lines to print uppercase j, too.