### PR TITLE
fix wording in documentation to make it simpler to follow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Alternatively, if you downloaded fcron as a tarball, see:
 If you cloned the git repo, you first need to build the documentation.
 On a Debian based system:
 ```
-$ sudo apt install -y docbook docbook-xsl docbook-xml docbook-utils manpages-dev
+$ sudo apt install -y autoconf build-essential docbook docbook-xsl docbook-xml docbook-utils manpages-dev
 $ autoconf
 $ ./configure  # optionally, use: --without-sendmail
 $ make updatedoc

--- a/doc/en/fcron.8.sgml
+++ b/doc/en/fcron.8.sgml
@@ -131,12 +131,12 @@ compiled to run in foreground as default.</para>
 		<term><option>--queuelen</option> <replaceable>num</replaceable></term>
 		<listitem>
 		    <para>Sets the size of the queue that is used to manage serial
-			jobs to <replaceable>num</replaceable>.
-			This means that at most <replaceable>num</replaceable> jobs can be
-			in the waiting state.
-			This also pertains to the lavg queue, i.e. at most
-			<replaceable>num</replaceable> jobs can wait until the system average
-			load drops below a certain value.
+			jobs and the lavg queue each to <replaceable>num</replaceable>.
+			This means that
+			(A) at most <replaceable>num</replaceable> serial jobs can be
+			in the waiting state and
+			(B) at most <replaceable>num</replaceable> jobs can wait until the
+			system average load drops below a certain value.
 			</para>
 		</listitem>
 	    </varlistentry>

--- a/doc/en/fcron.8.sgml
+++ b/doc/en/fcron.8.sgml
@@ -130,7 +130,7 @@ compiled to run in foreground as default.</para>
 		<term><option>-q</option> <replaceable>num</replaceable></term>
 		<term><option>--queuelen</option> <replaceable>num</replaceable></term>
 		<listitem>
-		    <para>Sets the size of the queue that is used to manage serial
+		    <para>Sets the sizes of the queues that are used to manage serial
 			jobs and the lavg queue each to <replaceable>num</replaceable>.
 			This means that
 			(A) at most <replaceable>num</replaceable> serial jobs can be

--- a/doc/en/fcron.8.sgml
+++ b/doc/en/fcron.8.sgml
@@ -121,9 +121,8 @@ compiled to run in foreground as default.</para>
 		<term><option>--maxserial</option>
 <replaceable>num</replaceable></term>
 		<listitem>
-		  <para>Set to <replaceable>num</replaceable> the maximum number
-		     of serial jobs which can run simultaneously. By default,
-		     this value is set to &serialmaxrunning;.</para>
+		  <para>Run at most <replaceable>num</replaceable> serial jobs
+		     simultaneously. By default, this value is set to &serialmaxrunning;.</para>
 		    <para>&seealso; option &optserial; in &fcrontab;(5).</para>
 		</listitem>
 	    </varlistentry>
@@ -131,8 +130,14 @@ compiled to run in foreground as default.</para>
 		<term><option>-q</option> <replaceable>num</replaceable></term>
 		<term><option>--queuelen</option> <replaceable>num</replaceable></term>
 		<listitem>
-		    <para>Set to n the number of jobs the serial queue and
-the lavg queue can contain.</para>
+		    <para>Sets the size of the queue that is used to manage serial
+			jobs to <replaceable>num</replaceable>.
+			This means that at most <replaceable>num</replaceable> jobs can be
+			in the waiting state.
+			This also pertains to the lavg queue, i.e. at most
+			<replaceable>num</replaceable> jobs can wait until the system average
+			load drops below a certain value.
+			</para>
 		</listitem>
 	    </varlistentry>
 	    <varlistentry>
@@ -145,7 +150,7 @@ the lavg queue can contain.</para>
 <filename>&etc;/&fcron.conf.location;</filename>. To interact with that running
 &fcron; process, &fcrontab; must use the same config file (which is defined by
 &fcrontab;'s option <option>-c</option>). That way, several &fcron; processes
-can run simultaneously on an only system (but each &fcron; process *must* have a
+can run simultaneously on a single system (but each &fcron; process *must* have a
 different spool dir and pid file from the other processes).</para>
 		</listitem>
 	    </varlistentry>

--- a/doc/en/fcron.conf.5.sgml
+++ b/doc/en/fcron.conf.5.sgml
@@ -34,8 +34,8 @@ A copy of the license is included in gfdl.sgml.
 			</para>
 		</abstract>
 		<para>
-			Blank lines, line beginning by a hash sign (#) (which are
-			considered comments), leading blanks and tabs are ignored. Each line in a
+			Blank lines, lines beginning with a hash sign (#) (which are
+			considered as comments), leading blanks and tabs are ignored. Each line in a
 			&fcron.conf; file is of the form
 			<blockquote>
 				<para>name = value</para>

--- a/doc/en/fcrondyn.1.sgml
+++ b/doc/en/fcrondyn.1.sgml
@@ -72,7 +72,7 @@ and a list of commands.</para>
 <replaceable>file</replaceable> instead of default config file
 <filename>&etc;/&fcron.conf.location;</filename>. To interact with a running
 &fcron; process, &fcrondyn; must use the same config file as the process. That
-way, several &fcron; processes can run simultaneously on an only system.</para>
+way, several &fcron; processes can run simultaneously on a single system.</para>
 		</listitem>
 	    </varlistentry>
 	    <varlistentry>

--- a/doc/en/fcrontab.1.sgml
+++ b/doc/en/fcrontab.1.sgml
@@ -18,7 +18,7 @@ A copy of the license is included in gfdl.sgml.
       </refmeta>
       <refnamediv>
 	 <refname>fcrontab</refname> <refpurpose>manipulate per-user fcrontab
-	    files which adhere to the format defined in fcrontab(5)</refpurpose>
+	    files which adhere to the format defined in <link linkend="fcrontab.5">&fcrontab;(5)</link></refpurpose>
       </refnamediv>
 
       <refsynopsisdiv id="fcrontab.1.synopsis">
@@ -53,23 +53,27 @@ A copy of the license is included in gfdl.sgml.
 	    linkend="fcron.8">&fcron;(8)</link> daemon. As &fcron; internally
 	    uses a non-human readable format (this is needed because &fcron;
 	    saves more informations than the user gives, for example the time
-	    and date of next execution), the user cannot edit his &fcrontabf;
+	    and date of next execution), the user cannot edit their &fcrontabf;
 		directly (the one used by &fcron;).</para> <para>When a user
 	    installs a &fcrontabf;, the source file is saved in the spool
 	    directory (<filename>&fcrontabsdir;</filename>) to allow it to be
 	    edited, and a formatted file is generated for the &fcron; daemon.
-		This formatted (non human readable) format is sent to the daemon
-		once per minute (about ten seconds before the full minute) with all
-		recent changes included. The daemon is not informed of the changes
-	    immediately but at most once a minute
+		This formatted (non human readable) file with all recent changes
+		included is then sent to the daemon.
+		The daemon is not informed of the changes immediately but after some time
 	    to keep ill disposed users from blocking the daemon by installing
-	    &fcrontabf;s over and over (i.e. denial of service attack). We will call
+	    &fcrontabf;s over and over (i.e. denial of service attack).
+		By default, the file is sent once per minute (about ten seconds before
+		the full minute) to the daemon, the parameter
+		<option>--with-max-fcrontab-reload-delay-seconds</option>
+		can be used to specify a different maximum time to send this data.
+		We will call
 	    "<emphasis>fcrontab</emphasis>" the source file of the &fcrontabf;
 	    in the following.</para>
 		<para>The fcrontab files that a user modifies has to follow the format
 		defined in <link linkend="fcrontab.5">&fcrontab;(5)</link> .</para>
-		<para>A user can install a &fcrontabf; if
-	    he is listed in <filename>&etc;/&fcron.allow;</filename> and not listed in
+		<para>Users can install a &fcrontabf; if
+	    they are listed in <filename>&etc;/&fcron.allow;</filename> and not listed in
 	    <filename>&etc;/&fcron.deny;</filename> (see section "<link
 	    linkend="fcrontab.1.files">files</link>" below).
 		The keyword 'all' is a shorthand for all users. If neither
@@ -77,13 +81,13 @@ A copy of the license is included in gfdl.sgml.
 	    exist, all users are allowed. None of these files have to exist, but
 	    if they do, the deny file takes precedence.</para> <para>The first
 	    form of the command is used to install a new &fcrontabf; file, from
-	    any named file or from standard input if the pseudo-filename "-" is
-	    given, replacing the previous one (if any): each user can have only
+	    any named file or from standard input (if the pseudo-filename "-" is
+	    given), replacing the previous one (if any). Each user can have only
 	    one &fcrontabf;.</para> <para>For instance, root can create a
 	    systemwide fcrontab file, say <filename>/etc/fcrontab</filename>,
 	    and run "<command>fcrontab</command>
 	    <filename>/etc/fcrontab</filename>" to install the new version after
-	    each change of the file. Or (s)he can create a new fcrontab running
+	    each change of the file. Or root can create a new fcrontab running
 	    a simple "<command>fcrontab</command>", and then maintain it using
 	    "<command>fcrontab</command> <option>-e</option>". Same
 	    considerations apply to a non privileged user.</para>

--- a/doc/en/fcrontab.1.sgml
+++ b/doc/en/fcrontab.1.sgml
@@ -18,7 +18,7 @@ A copy of the license is included in gfdl.sgml.
       </refmeta>
       <refnamediv>
 	 <refname>fcrontab</refname> <refpurpose>manipulate per-user fcrontab
-	    files</refpurpose>
+	    files which adhere to the format defined in fcrontab(5)</refpurpose>
       </refnamediv>
 
       <refsynopsisdiv id="fcrontab.1.synopsis">
@@ -53,22 +53,26 @@ A copy of the license is included in gfdl.sgml.
 	    linkend="fcron.8">&fcron;(8)</link> daemon. As &fcron; internally
 	    uses a non-human readable format (this is needed because &fcron;
 	    saves more informations than the user gives, for example the time
-	    and date of next execution), the user cannot edit directly his
-	    &fcrontabf; (the one used by &fcron;).</para> <para>When a user
+	    and date of next execution), the user cannot edit his &fcrontabf;
+		directly (the one used by &fcron;).</para> <para>When a user
 	    installs a &fcrontabf;, the source file is saved in the spool
-	    directory (<filename>&fcrontabsdir;</filename>) to allow future
-	    editions, and a formatted file is generated for the &fcron; daemon,
-	    which is signaled once about ten seconds before the next minute for
-	    all changes made previously. The daemon is not informed of the changes
+	    directory (<filename>&fcrontabsdir;</filename>) to allow it to be
+	    edited, and a formatted file is generated for the &fcron; daemon.
+		This formatted (non human readable) format is sent to the daemon
+		once per minute (about ten seconds before the full minute) with all
+		recent changes included. The daemon is not informed of the changes
 	    immediately but at most once a minute
 	    to keep ill disposed users from blocking the daemon by installing
-	    &fcrontabf;s over and over (ie. denial of service attack). We will call
+	    &fcrontabf;s over and over (i.e. denial of service attack). We will call
 	    "<emphasis>fcrontab</emphasis>" the source file of the &fcrontabf;
-	    in the following.</para> <para>A user can install a &fcrontabf; if
-	    he is listed in the <filename>&etc;/&fcron.allow;</filename> and not
-	    (unless by the keyword all) listed in
+	    in the following.</para>
+		<para>The fcrontab files that a user modifies has to follow the format
+		defined in <link linkend="fcrontab.5">&fcrontab;(5)</link> .</para>
+		<para>A user can install a &fcrontabf; if
+	    he is listed in <filename>&etc;/&fcron.allow;</filename> and not listed in
 	    <filename>&etc;/&fcron.deny;</filename> (see section "<link
-	    linkend="fcrontab.1.files">files</link>" below). If neither
+	    linkend="fcrontab.1.files">files</link>" below).
+		The keyword 'all' is a shorthand for all users. If neither
 	    <filename>fcron.allow</filename> nor <filename>fcron.deny</filename>
 	    exist, all users are allowed. None of these files have to exist, but
 	    if they do, the deny file takes precedence.</para> <para>The first
@@ -154,7 +158,7 @@ A copy of the license is included in gfdl.sgml.
 		     file <filename>&etc;/&fcron.conf.location;</filename>. To
 		     interact with a running &fcron; process, &fcrontab; must
 		     use the same config file as the process. That way, several
-		     &fcron; processes can run simultaneously on an only
+		     &fcron; processes can run simultaneously on a single
 		     system.</para>
 	       </listitem>
 	    </varlistentry>

--- a/doc/en/fcrontab.1.sgml
+++ b/doc/en/fcrontab.1.sgml
@@ -64,7 +64,7 @@ A copy of the license is included in gfdl.sgml.
 	    to keep ill disposed users from blocking the daemon by installing
 	    &fcrontabf;s over and over (i.e. denial of service attack).
 		By default, the file is sent once per minute (about ten seconds before
-		the full minute) to the daemon, the parameter
+		the full minute) to the daemon, the build time parameter
 		<option>--with-max-fcrontab-reload-delay-seconds</option>
 		can be used to specify a different maximum time to send this data.
 		We will call

--- a/doc/en/fcrontab.5.sgml
+++ b/doc/en/fcrontab.5.sgml
@@ -19,7 +19,7 @@ A copy of the license is included in gfdl.sgml.
     </refmeta>
     <refnamediv>
 	<refname>fcrontab</refname>
-	<refpurpose>file format to define the schedule that fcron should adhere to</refpurpose>
+	<refpurpose>file format to define the jobs that fcron should run, and their schedules.</refpurpose>
     </refnamediv>
 
     <refsect1>

--- a/doc/en/fcrontab.5.sgml
+++ b/doc/en/fcrontab.5.sgml
@@ -19,7 +19,7 @@ A copy of the license is included in gfdl.sgml.
     </refmeta>
     <refnamediv>
 	<refname>fcrontab</refname>
-	<refpurpose>tables for driving fcron</refpurpose>
+	<refpurpose>file format to define the schedule that fcron should adhere to</refpurpose>
     </refnamediv>
 
     <refsect1>
@@ -27,7 +27,8 @@ A copy of the license is included in gfdl.sgml.
 	<para>A &fcrontabf; is a file containing all tables used by the
 &fcron;(8) daemon. In other words, it is the means for a user to tell the daemon
 "execute this command at this moment". Each user has their own &fcrontabf;, whose
-commands are executed as their owner (only root can run a job as another using the
+commands are executed on behalf of their owner (in particular with the users
+permissions -- only root can run a job as another using the
 option &optrunas; (see below)).</para>
 	<para>Blank lines, line beginning by a hash sign (#) (which are
 considered comments), leading blanks and tabs are ignored. Each line in a
@@ -522,7 +523,7 @@ abbreviation. The options are (default value in parentheses):</para>
 		    <term>b</term>
 		    <listitem>
 			<para><emphasis><type>boolean</type></emphasis>(<constant>false</constant>)</para>
-			<para>Run an &amp;-line at &fcron;'s startup (or system's resume after suspend/hibernation) if it should
+			<para>Run an &amp;-line (i.e. based on date and time) at &fcron;'s startup (or system's resume after suspend/hibernation) if it should
 have run during system down time.</para>
 		    </listitem>
 		</varlistentry>

--- a/doc/en/readme.sgml
+++ b/doc/en/readme.sgml
@@ -25,7 +25,7 @@ and better :)) ...</para>
 
 	<para>To do so, &fcron; allows you to use the standard mode in which you
 tell it to execute one command at a given date and time. Alternatively you can
-instruct &fcron; to execute a command after a certain time of &fcron;'s runtime
+instruct &fcron; to execute a command after a certain duration of &fcron;'s runtime
 (which is normally the same as system up time because &fcron; is typically started
 on boot). For example:
 

--- a/doc/en/readme.sgml
+++ b/doc/en/readme.sgml
@@ -17,16 +17,17 @@ A copy of the license is included in gfdl.sgml.
 Cron</application>, so it implements most of its functionalities.</para>
 	<para>But contrary to <application>Vixie Cron</application>, &fcron;
 does not need your system to be up 7 days a week, 24 hours a day: it also works
-well with systems which are not running neither all the time nor regularly
+well with systems which are neither running all the time nor regularly
 (contrary to <application>anacrontab</application>).</para>
 	<para>In other words, &fcron; does both the job of <application>Vixie
 Cron</application> and <application>anacron</application>, but does even more
 and better :)) ...</para>
 
 	<para>To do so, &fcron; allows you to use the standard mode in which you
-tell it to execute one command at a given date and hour and to make it run a
-command according to its time of execution, which is normally the same as system
-up time. For example:
+tell it to execute one command at a given date and time. Alternatively you can
+instruct &fcron; to execute a command after a certain time of &fcron;'s runtime
+(which is normally the same as system up time because &fcron; is typically started
+on boot). For example:
 
             <blockquote>
 		<para>Run the task 'save /home/ directory' every 3h15 of system
@@ -34,7 +35,7 @@ up time.</para>
 	    </blockquote> and, of course, in order to make it really useful, the
 time remaining until next execution is saved each time the system is stopped.
 You can also say:
-	
+
             <blockquote>
 		<para>run that command once between 2am and 5am</para>
             </blockquote> which will be done if the system is running at any


### PR DESCRIPTION
I stumbled over some words in the documentation.
In this PR I tried to 'iron out' those places.