### PR TITLE
Check for fdatasync, and fall back to fsync if missing

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -240,6 +240,12 @@
 /* Define if you have the flock function.  */
 #undef HAVE_FLOCK
 
+/* Define if you have the fdatasync function.  */
+#undef HAVE_FDATASYNC
+
+/* Define if the headers actually declare the fdatasync function.  */
+#undef HAVE_DECL_FDATASYNC
+
 /* Define if you have the lockf function.  */
 #undef HAVE_LOCKF
 

--- a/configure.in
+++ b/configure.in
@@ -106,6 +106,8 @@ fi
 AC_CHECK_FUNCS(getcwd gettimeofday mktime putenv strerror setenv unsetenv gethostname)
 AC_CHECK_FUNCS(getopt_long)
 AC_CHECK_FUNCS(mkstemp)
+AC_CHECK_FUNCS(fdatasync)
+AC_CHECK_DECLS(fdatasync)
 AC_CHECK_FUNCS(flock lockf)
 AC_CHECK_FUNCS(setlinebuf)
 AC_CHECK_FUNCS(sigaction)

--- a/global.h
+++ b/global.h
@@ -168,6 +168,14 @@
 #endif
 
 /* macros */
+/* macOS has an fdatasync to link against, but doesn't declare or document it.
+ * Apple Clang suppresses the warning/error when calling it, which causes
+ * HAVE_FDATASYNC to be defined. But other compilers (including upstream Clang)
+ * don't. So we have to check both to see if we can safely use it. */
+#if !defined(HAVE_FDATASYNC) || !HAVE_DECL_FDATASYNC
+#define fdatasync(arg) fsync(arg)
+#endif
+
 #ifndef HAVE_SETEUID
 #define seteuid(arg) setresuid(-1,(arg),-1)
 #endif


### PR DESCRIPTION
Not all systems define `fdatasync`, and `fsync` does a strict superset of what `fdatasync` does.

macOS has an `fdatasync` function in its standard library, but doesn't declare or document it. Apple Clang hides the warning/error when you try to call it without a declaration, but other compilers (including upstream Clang) don't. This is currently causing the [Nix](https://nixos.org/) [package for `fcron`](https://github.com/NixOS/nixpkgs/blob/nixpkgs-unstable/pkgs/by-name/fc/fcron/package.nix) to [fail to build on macOS](https://hydra.nixos.org/build/329275907/log).